### PR TITLE
Fix error when serializing CollectionItems (oPersistent) that have references to other ORM objects.

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -34132,7 +34132,7 @@ begin
           Obj := pointer(GetOrdProp(Value,pointer(P)));  // works also for CPU64
           if (IsObj<>oSQLMany) or
              not(IdemPropName(P^.Name,'source') or IdemPropName(P^.Name,'dest')) then
-            if (IsObj in [oSQLRecord,oSQLMany]) and
+            if (IsObj in [oSQLRecord,oPersistent,oSQLMany]) and
                (P^.PropType^^.ClassSQLFieldType=sftID) and
                not TSQLRecord(Value).fFill.JoinedFields then begin
               HR(P);


### PR DESCRIPTION
Fix error when serializing CollectionItems (oPersistent) that have references to other ORM objects.

Otherwhise error is thwon at the very start of TJSONSerializer.WriteObject as aClassType can not be retieved.
