### PR TITLE
Update SynCrtSock.pas

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -185,6 +185,8 @@ unit SynCrtSock;
   - fixed several issues when releasing THttpApiServer and THttpServer instances
   - allow to use any Unicode content for SendEmail() - also includes
     SendEmailSubject() function, for feature request [0a5fdf9129]
+  - renamed IgnoreSSLCertificate to IgnoreSSLCertificateErrors and implemented in
+    parameters of class functions.
  }
 
 {$I Synopse.inc} // define HASINLINE USETYPEINFO CPU32 CPU64 OWNNORMTOUPPER


### PR DESCRIPTION
Hi Arnaud, here is the implementation of ignore SSL certificate errors on TWinHTTPAPI (useful for testing) through parameters. IgnoreSSLCertificateErrors renamed and moved to TWinHTTPApi base class.
