### PR TITLE
Corrected support for limitation number of rows in Oracle SQL queries with order by clause.

### DIFF
--- a/SQLite3/mORMotDB.pas
+++ b/SQLite3/mORMotDB.pas
@@ -910,13 +910,16 @@ begin
     end;
     if Stmt.Limit=0 then
       limit.Position := posNone else begin
-      limit := fProperties.SQLLimitClause;
+      limit := fProperties.SQLLimitClause(Stmt);
       if limit.Position=posNone then begin
         InternalLog('%.AdaptSQLForEngineList: unknown "%" LIMIT syntax for [%]',
           [ClassType,ToText(fProperties.DBMS)^,SQL],sllWarning);
         exit;
       end;
-      limitSQL := FormatUTF8(limit.InsertFmt,[Stmt.Limit]);
+      if  limit.Position = posOuter then
+        limitSQL := FormatUTF8(limit.InsertFmt,['%', Stmt.Limit])
+      else
+        limitSQL := FormatUTF8(limit.InsertFmt,[Stmt.Limit]);
     end;
     extFieldName := fStoredClassProps.ExternalDB.FieldNameByIndex;
     W := TTextWriter.CreateOwnedStream(1024);
@@ -1020,6 +1023,8 @@ begin
       if limit.Position=posAfter then
         W.AddString(limitSQL);
       W.SetText(SQL);
+      if limit.Position = posOuter then
+        SQL := FormatUTF8(limitSQL, [SQL]);
       result := true;
     finally
       W.Free;

--- a/SynDB.pas
+++ b/SynDB.pas
@@ -1009,7 +1009,7 @@ type
 
   /// where the LIMIT clause should be inserted for a given SQL syntax
   // - used by TSQLDBDefinitionLimitClause and SQLLimitClause() method
-  TSQLDBDefinitionLimitPosition = (posNone, posWhere, posSelect, posAfter);
+  TSQLDBDefinitionLimitPosition = (posNone, posWhere, posSelect, posAfter, posOuter);
 
   /// defines the LIMIT clause to be inserted for a given SQL syntax
   // - used by TSQLDBDefinitionLimitClause and SQLLimitClause() method
@@ -1532,7 +1532,7 @@ type
     // statement to a syntax matching the underlying DBMS
     // - e.g. TSQLRestStorageExternal.AdaptSQLForEngineList() calls this
     // to let TSQLRestServer.URI by-pass virtual table mechanism
-    function SQLLimitClause: TSQLDBDefinitionLimitClause; virtual;
+    function SQLLimitClause(const AStmt: TSynTableStatement): TSQLDBDefinitionLimitClause; virtual;
     /// determine if the SQL statement can be cached
     // - used by TSQLDBConnection.NewStatementPrepared() for handling cache
     function IsCachable(P: PUTF8Char): boolean; virtual;
@@ -6260,7 +6260,7 @@ begin
   result := StringReplaceAll(fDatabaseName,PassWord,'***');
 end;
 
-function TSQLDBConnectionProperties.SQLLimitClause: TSQLDBDefinitionLimitClause;
+function TSQLDBConnectionProperties.SQLLimitClause(const AStmt: TSynTableStatement): TSQLDBDefinitionLimitClause;
 begin
   result := DB_SQLLIMITCLAUSE[DBMS];
 end;

--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -237,6 +237,7 @@ type
     // - e.g. ExtractTnsName('1.2.3.4:1521/dbname') returns 'dbname'
     class function ExtractTnsName(const aServerName: RawUTF8): RawUTF8;
     procedure PasswordChanged(const ANewPassword: RawUTF8);
+    function SQLLimitClause(const AStmt: TSynTableStatement): TSQLDBDefinitionLimitClause; override;
   published
     /// returns the Client version e.g. 'oci.dll rev. 11.2.0.1'
     property ClientVersion: RawUTF8 read GetClientVersion;
@@ -1865,6 +1866,17 @@ begin
   SynDBLog.Add.Log(sllDB, 'Password to database account was changed.');
   if Assigned(FOnPasswordChanged) then
     FOnPasswordChanged(Self);
+end;
+
+function TSQLDBOracleConnectionProperties.SQLLimitClause(const AStmt: TSynTableStatement): TSQLDBDefinitionLimitClause;
+begin
+  if AStmt.OrderByField <> nil then
+  begin
+    Result.Position := posOuter;
+    Result.InsertFmt := 'select * from (%) where rownum <=%';
+  end
+  else
+    Result := inherited SQLLimitClause(AStmt);
 end;
 
 { TSQLDBOracleConnection }


### PR DESCRIPTION
According to http://synopse.info/forum/viewtopic.php?id=3274 I added changes to mORMot source.