### PR TITLE
Path separator must be "/"

### DIFF
--- a/SynZip.pas
+++ b/SynZip.pas
@@ -1025,8 +1025,9 @@ begin
       GetFileTime(S.Handle,nil,nil,@Time);
       FileTimeToLocalFileTime(Time,Time);
       FileTimeToDosDateTime(Time,FileTime.Hi,FileTime.Lo);
-    {$else}
-        ZipName := StringReplace(aFileName,'/','\',[rfReplaceAll]);
+      ZipName := StringReplace(aFileName,'\','/',[rfReplaceAll]);
+      if (Length(ZipName) >= 2) and (ZipName[2]=':') then
+        Delete(ZipName, 2,1); //replace drive letter by 1 letter dir
     {$endif}
     Size := S.Size;
     if Size64.Hi<>0 then


### PR DESCRIPTION
From ZIP file specification 2014 https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, chapter 4.4.17:
- it is forbidden to have a drive letter in path
- path separator MUST be "/" and not "\"

The patches reverses the change from '/' to '\' for others OS than windows to a change from '\' to '/' for windows and replace drive letter by a letter path