### PR TITLE
Path separator must be "/", drive letter is forbidden

### DIFF
--- a/SynZip.pas
+++ b/SynZip.pas
@@ -1020,14 +1020,14 @@ begin
     if ZipName='' then
       if RemovePath then
         ZipName := ExtractFileName(aFileName) else
-    {$ifdef MSWINDOWS}
         ZipName := aFileName;
-      GetFileTime(S.Handle,nil,nil,@Time);
-      FileTimeToLocalFileTime(Time,Time);
-      FileTimeToDosDateTime(Time,FileTime.Hi,FileTime.Lo);
-      ZipName := StringReplace(aFileName,'\','/',[rfReplaceAll]);
-      if (Length(ZipName) >= 2) and (ZipName[2]=':') then
-        Delete(ZipName, 2,1); //replace drive letter by 1 letter dir
+    {$ifdef MSWINDOWS}
+    GetFileTime(S.Handle,nil,nil,@Time);
+    FileTimeToLocalFileTime(Time,Time);
+    FileTimeToDosDateTime(Time,FileTime.Hi,FileTime.Lo);
+    ZipName := StringReplace(aFileName,'\','/',[rfReplaceAll]);
+    if (Length(ZipName) >= 2) and (ZipName[2]=':') then
+      Delete(ZipName, 2,1); //replace drive letter by 1 letter dir
     {$endif}
     Size := S.Size;
     if Size64.Hi<>0 then


### PR DESCRIPTION
From ZIP file specification 2014 https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, chapter 4.4.17:
- path separator MUST be "/" (and not "\")
- it is forbidden to have a drive letter in path

The patches reverses the change from '/' to '\' for others OS than windows to a change from '\' to '/' for windows and replace drive letter by a letter path
