### PR TITLE
Revert commit: try to circumvent weird XE4/XE5 compiler issues.

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -4253,13 +4253,6 @@ const
     Size: sizeof(TGUID);
     Count: 0);
 
-{$ifndef HASDIRECTTYPEINFO}
-{$ifdef HASINLINENOTX86}
-// declared in interface section to circumvent weird XE4/XE5 compiler issues
-function Deref(Info: PPTypeInfo): PTypeInfo; inline;
-{$endif HASINLINENOTX86}
-{$endif HASDIRECTTYPEINFO}
-
 /// returns the interface name of a registered GUID, or its hexadecimal value
 function ToText(const aGUID: TGUID): TGUIDShortString; overload;
 
@@ -20215,7 +20208,7 @@ type
   Deref = PTypeInfo;
 {$else}
 function Deref(Info: PPTypeInfo): PTypeInfo;
-{$ifdef HASINLINENOTX86}
+{$ifdef HASINLINENOTX86} inline;
 begin
   if Info=nil then
     result := pointer(Info) else


### PR DESCRIPTION
Revert commit: try to circumvent weird XE4/XE5 compiler issues. Problem was due to wrong Synopse.inc content in local copy. Now, when the reason of problem is known, change could be reverted.