### PR TITLE
Fix AV error for TSynLocker.Done (don't clear Padding items for VType…

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -49170,7 +49170,8 @@ procedure TSynLocker.Done;
 var i: integer;
 begin
   for i := 0 to PaddingMaxUsedIndex do
-    VarClear(variant(Padding[i]));
+    if Padding[i].VType<>varUnknown then  
+      VarClear(variant(Padding[i]));
   DeleteCriticalSection(fSection);
 end;
 


### PR DESCRIPTION
… = varUnknown)