### PR TITLE
Comma is not needed after {$ifdef FPCUSEVERSIONINFO}

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -18296,7 +18296,7 @@ uses
   {$endif}
   {$endif}
   {$ifndef MSWINDOWS}
-    {$ifdef FPCUSEVERSIONINFO}, // should be enabled in Synopse.inc
+    {$ifdef FPCUSEVERSIONINFO} // should be enabled in Synopse.inc
     fileinfo, // FPC 3.0 and up
     winpeimagereader, // winpe exe info
     elfreader,  // ELF executables


### PR DESCRIPTION
This coused this unit to not compile under Linux