### PR TITLE
Fixed a bug in TSQLPropInfoRTTIDynArray.SetValue

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -23194,9 +23194,11 @@ begin
   if Value=nil then
     da.Clear else
     try
-      if (fObjArray=nil) and Base64MagicCheckAndDecode(Value,tmp) then
-        da.LoadFrom(tmp.buf) else 
-        da.LoadFromJSON(tmp.Init(Value));
+      if not Base64MagicCheckAndDecode(Value,tmp) then
+        tmp.Init(Value);
+      if (fObjArray=nil) then
+        da.LoadFrom(tmp.buf) else
+        da.LoadFromJSON(tmp.buf);
     finally
       tmp.Done;
     end;


### PR DESCRIPTION
Fixed a bug in TSQLPropInfoRTTIDynArray.SetValue which didn't try to decode base64 input if its fObjArray was assigned.