### PR TITLE
fix incomlete implementation of TPropInfo.isStored for FPC

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -29462,7 +29462,7 @@ type // function(Instance: TObject) trick does not work with CPU64 :(
 var Call: TMethod;
 begin
 {$ifdef FPC} // extracted from IsStoredProp() function in typinfo.pp
-  result := ((PropProcs shr 4) and 3=ptconst) and LongBool(StoredProc);
+  result := IsStoredProp(Instance, @Self);
 {$else}      // Delphi version
   if (StoredProc and (not PtrInt($ff)))=0 then
     result := boolean(StoredProc) else


### PR DESCRIPTION
FPC implementation of mORMot.TPropInfo.IsStored is incompleate for FPC compiler (handle only consts), so for case
```
TBaby = class
  private
    fName: RawUTF8;
  function canStoreName: boolean;
  published
    property Name: RawUTF8 read fName write fName stored canStoreName;
end;
```
Name property will never be stored