### PR TITLE
SynZip: use a SynZLibSSE by default for FPC/Win64

### DIFF
--- a/SynZip.pas
+++ b/SynZip.pas
@@ -177,7 +177,7 @@ unit SynZip;
       {.$define USEZLIBSSE} // SynZLibSSE static .o files for FPC + Win32 fails
     {$endif}
     {$ifdef Win64}
-      {$define USEZLIBSSE} // SynZLibSSE static .o files for FPC + Win64
+      {.$define USEZLIBSSE} // SynZLibSSE static .o files for FPC + Win64
     {$endif}
   {$else}
     {$define USEEXTZLIB}  // will use zlib.so under Linux/Posix
@@ -585,8 +585,10 @@ procedure zlibFreeMem(AppData, Block: Pointer);  cdecl;
 {$ifdef USEEZLIB}
 function ZLIB_VERSION: PAnsiChar;
 {$else}
+{$ifndef USEPASZLIB} // in case of USEPASZLIB zlib version is defined in zbase
 const
   ZLIB_VERSION = '1.2.5';
+{$endif}
 {$endif}
 
 const
@@ -1609,7 +1611,7 @@ begin
   if Len=0 then
     exit;
   SetLength(result,Len);
-  if (UnCompressMem(@gz[10],pointer(result),gzLen-18,Len)<>Len) or
+  if (UnCompressMem(@gz[10],pointer(result),gzLen-10,Len)<>Len) or
      (SynZip.crc32(0,pointer(result),Len)<>pCardinal(@gz[gzLen-8])^) then
     result := ''; // invalid CRC
 end;

--- a/SynZip.pas
+++ b/SynZip.pas
@@ -585,10 +585,8 @@ procedure zlibFreeMem(AppData, Block: Pointer);  cdecl;
 {$ifdef USEEZLIB}
 function ZLIB_VERSION: PAnsiChar;
 {$else}
-{$ifndef USEPASZLIB} // in case of USEPASZLIB zlib version is defined in zbase
 const
   ZLIB_VERSION = '1.2.5';
-{$endif}
 {$endif}
 
 const

--- a/SynZip.pas
+++ b/SynZip.pas
@@ -177,7 +177,7 @@ unit SynZip;
       {.$define USEZLIBSSE} // SynZLibSSE static .o files for FPC + Win32 fails
     {$endif}
     {$ifdef Win64}
-      {.$define USEZLIBSSE} // SynZLibSSE static .o files for FPC + Win64
+      {$define USEZLIBSSE} // SynZLibSSE static .o files for FPC + Win64
     {$endif}
   {$else}
     {$define USEEXTZLIB}  // will use zlib.so under Linux/Posix
@@ -5010,8 +5010,8 @@ var strm: TZStream;
   end;
 begin
   {$ifdef USEZLIBSSE}
-  result := CompressStreamSSE42(src,srcLen,aStream,@tempbuf.buf128k,
-    sizeof(tempbuf.buf128k),CompressionLevel,ZLibFormat);
+  result := CompressStreamSSE42(src,srcLen,aStream,@temp.buf128k,
+    sizeof(temp.buf128k),CompressionLevel,ZLibFormat);
   if result<>Z_VERSION_ERROR then
     exit; // SSE4.2 CloudFlare's fork did the work
   {$endif}


### PR DESCRIPTION
because of (possible) bug in fpc paszlib - see [this forum thread](https://synopse.info/forum/viewtopic.php?id=4400)