### PR TITLE
Fix SynOleDB for FPC & x64 target

### DIFF
--- a/SynOleDB.pas
+++ b/SynOleDB.pas
@@ -295,6 +295,10 @@ type
   DBPARAMFLAGS = DWORD;
   DBTYPE = Word;
   DBRESULTFLAG = UINT;
+
+  DBLENGTH = PtrUInt;
+  DB_UPARAMS = PtrUInt;
+
   PBoid = ^TBoid;
 {$ifdef CPU64}
   {$A8} // un-packed records
@@ -431,7 +435,7 @@ type
     iOrdinal: UINT;
     pwszName: PWideChar;
     pTypeInfo: ITypeInfo;
-    ulParamSize: UINT;
+    ulParamSize: DBLENGTH;
     wType: DBTYPE;
     bPrecision: Byte;
     bScale: Byte;
@@ -442,11 +446,8 @@ type
   TUintArray = array[0..MAXBOUND] of UINT;
   TUintDynArray = array of UINT;
 
-  DBLENGTH = PtrUInt;
-  DB_UPARAMS = PtrUInt;
-
   PDBParamBindInfo = ^TDBParamBindInfo;
-  DBPARAMBINDINFO = packed record
+  DBPARAMBINDINFO = record
     pwszDataSourceType: PWideChar;
     pwszName: PWideChar;
     ulParamSize: DBLENGTH;
@@ -923,6 +924,7 @@ type
   // but manual storage for better performance
   // - whole memory block of a TOleDBStatementParamDynArray will be used as the
   // source Data for the OleDB parameters - so we should align data carefully
+
   TOleDBStatementParam = packed record
     /// storage used for BLOB (ftBlob) values
     // - will be refered as DBTYPE_BYREF when sent as OleDB parameters, to

--- a/SynOleDB.pas
+++ b/SynOleDB.pas
@@ -297,9 +297,9 @@ type
   DBRESULTFLAG = UINT;
   PBoid = ^TBoid;
 {$ifdef CPU64}
-  {$A+} // un-packed records
+  {$A8} // un-packed records
 {$else}
-  {$A-} // packed records
+  {$A1} // packed records
 {$endif}
   TBoid = record
     rgb_: array[0..15] of Byte;
@@ -442,11 +442,14 @@ type
   TUintArray = array[0..MAXBOUND] of UINT;
   TUintDynArray = array of UINT;
 
+  DBLENGTH = PtrUInt;
+  DB_UPARAMS = PtrUInt;
+
   PDBParamBindInfo = ^TDBParamBindInfo;
   DBPARAMBINDINFO = packed record
     pwszDataSourceType: PWideChar;
     pwszName: PWideChar;
-    ulParamSize: UINT;
+    ulParamSize: DBLENGTH;
     dwFlags: DBPARAMFLAGS;
     bPrecision: Byte;
     bScale: Byte;
@@ -458,7 +461,7 @@ type
   TDBParamBindInfoDynArray = array of TDBParamBindInfo;
 
 {$ifndef CPU64}
-  {$A+} // packed records
+  {$A1} // packed records
 {$endif}
 
   /// initialize and uninitialize OleDB data source objects and enumerators
@@ -536,7 +539,7 @@ type
       ppNamesBuffer: PPOleStr): HResult; stdcall;
     function MapParameterNames(cParamNames: UINT; rgParamNames: POleStrList;
       rgParamOrdinals: PUintArray): HResult; stdcall;
-    function SetParameterInfo(cParams: UINT; rgParamOrdinals: PUintArray;
+    function SetParameterInfo(cParams: DB_UPARAMS; rgParamOrdinals: PPtrUIntArray ;
       rgParamBindInfo: PDBParamBindInfoArray): HResult; stdcall;
   end;
 
@@ -1827,8 +1830,8 @@ var i: integer;
     res: HResult;
     fParamBindInfo: TDBParamBindInfoDynArray;
     BI: PDBParamBindInfo;
-    fParamOrdinals: TUintDynArray;
-    PO: PUINT;
+    fParamOrdinals: TPtrUIntDynArray;
+    PO: PPtrUInt;
     dbObjTVP: TDBObject;
     ssPropParamIDList: TDBPROP;
     ssPropsetParamIDList: TDBPROPSET;


### PR DESCRIPTION
This patch fix SynOleDB for FPC & x64 target:
 - FPC don't understand {$A+} {$A-} instruction, replaced by {$A8} {$A1} 
- ULONG/TUIntDynArray replaced by PtrUInt/TPtrUIntDynArray where expected
- `packed` keyword removed from records for proper alignment
- minor refactoring of Int64/UTF8 array binding

Verified with XE2 Win32 & FPC311 Win64 (hope also work with Delphi x64)
