### PR TITLE
Patched version of mozjs library is renamed

### DIFF
--- a/SyNode/README.md
+++ b/SyNode/README.md
@@ -13,9 +13,9 @@
 
 Precompiled binary can be downloaded here:
 
-  - x32: https://unitybase.info/downloads/synmozjs52x32dlls.zip
-  - x64: https://unitybase.info/downloads/synmozjs52x64dlls.zip
-  - Linux x64: http://unitybase.info/media/files/libsynmozjs52.zip
+  - Win x32: https://unitybase.info/media/files/synmozjs52x32dlls.zip
+  - Win x64: https://unitybase.info/media/files/synmozjs52x64dlls.zip
+  - Linux x64: https://unitybase.info/media/files/libsynmozjs52.zip
 
 Or compiled from sources as described [in  instructions inside mozjs folder](/mozjs)
 

--- a/SyNode/README.md
+++ b/SyNode/README.md
@@ -4,7 +4,7 @@
 - based on SpiderMonkey52, almost full support of ES6
 - a remote debugger protocol, can be debugged remotely using Firefox - see `SyNode\Samples\02 - Bindings`
 - CommonJS modules, compatible with NPM modules
-- nairve modules can be implemented using Delphi/FPC (as a dll/so) - see `SyNode\Samples\01 - Dll Modules`
+- native modules can be implemented using Delphi/FPC (as a dll/so) - see `SyNode\Samples\01 - Dll Modules`
 - JavaScript prototype definition based on Delphi RTTI (supported both "new" and old)
 
 ## SpiderMonkey library 
@@ -13,11 +13,10 @@
 
 Precompiled binary can be downloaded here:
 
-  - x32: https://unitybase.info/downloads/mozjs-52x32dlls.zip
-  - x64: https://unitybase.info/downloads/mozjs-52x64dlls.zip
-  - Linux x64: http://unitybase.info/media/files/libmozjs-52.zip
-  - Linux 64 (glibc2.17): http://unitybase.info/media/files/libmozjs-52-glibc2-17.zip 
- 
+  - x32: https://unitybase.info/downloads/synmozjs52x32dlls.zip
+  - x64: https://unitybase.info/downloads/synmozjs52x64dlls.zip
+  - Linux x64: http://unitybase.info/media/files/libsynmozjs52.zip
+
 Or compiled from sources as described [in  instructions inside mozjs folder](/mozjs)
 
 ### SpiderMonkey 45 (not supported)

--- a/SyNode/SpiderMonkey.pas
+++ b/SyNode/SpiderMonkey.pas
@@ -2194,7 +2194,7 @@ function SimpleVariantToJSval(cx: PJSContext; val: Variant): jsval;
 
 const
 {$IFDEF SM52}
-  SpiderMonkeyLib = 'mozjs-52'{$IFDEF MSWINDOWS} + '.dll'{$ENDIF};
+  SpiderMonkeyLib = 'synmozjs52'{$IFDEF MSWINDOWS} + '.dll'{$ENDIF};
 {$ELSE}
   SpiderMonkeyLib = 'mozjs-45'{$IFDEF MSWINDOWS} + '.dll'{$ENDIF};
 {$ENDIF}

--- a/SyNode/SyNodeNewProto.pas
+++ b/SyNode/SyNodeNewProto.pas
@@ -54,13 +54,6 @@ unit SyNodeNewProto;
   ***** END LICENSE BLOCK *****
 
 
-  ---------------------------------------------------------------------------
-   Download the mozjs-45 library at
-     x32: https://unitybase.info/downloads/mozjs-45.zip
-     x64: https://unitybase.info/downloads/mozjs-45-x64.zip
-  ---------------------------------------------------------------------------
-
-
   Version 1.18
   - initial release. Use SpiderMonkey 45
   - added TDateTime conversion as proposed by hsvandrew

--- a/SyNode/SyNodeProto.pas
+++ b/SyNode/SyNodeProto.pas
@@ -53,13 +53,6 @@ unit SyNodeProto;
   ***** END LICENSE BLOCK *****
 
 
-  ---------------------------------------------------------------------------
-   Download the mozjs-45 library at
-     x32: https://unitybase.info/downloads/mozjs-45.zip
-     x64: https://unitybase.info/downloads/mozjs-45-x64.zip
-  ---------------------------------------------------------------------------
-
-
   Version 1.18
   - initial release. Use SpiderMonkey 45
 

--- a/SyNode/SyNodeRemoteDebugger.pas
+++ b/SyNode/SyNodeRemoteDebugger.pas
@@ -54,13 +54,6 @@ unit SyNodeRemoteDebugger;
   ***** END LICENSE BLOCK *****
 
 
-  ---------------------------------------------------------------------------
-   Download the mozjs-45 library at
-     x32: https://unitybase.info/downloads/mozjs-45.zip
-     x64: https://unitybase.info/downloads/mozjs-45-x64.zip
-  ---------------------------------------------------------------------------
-
-
   Version 1.18
   - initial release. Use SpiderMonkey 45
 

--- a/SyNode/SyNodeSimpleProto.pas
+++ b/SyNode/SyNodeSimpleProto.pas
@@ -53,13 +53,6 @@ unit SyNodeSimpleProto;
   ***** END LICENSE BLOCK *****
 
 
-  ---------------------------------------------------------------------------
-   Download the mozjs-45 library at
-     x32: https://unitybase.info/downloads/mozjs-45.zip
-     x64: https://unitybase.info/downloads/mozjs-45-x64.zip
-  ---------------------------------------------------------------------------
-
-
   Version 1.18
   - initial release. Use SpiderMonkey 45
 

--- a/SyNode/mozjs/BuildInstructionSM52-linux.md
+++ b/SyNode/mozjs/BuildInstructionSM52-linux.md
@@ -74,4 +74,13 @@ And now run build itself:
 make
 ```
 
-Upon successfull build go to dist/bin subdirectory and take libmozjs-52.so library. It is recommended to copy this file to `/usr/lib` directory
+Upon successfull build go to dist/bin subdirectory and take libmozjs-52.so library.
+To avoid conflicts with a packaged version of this library the name have to be changed, but issuing mv command to rename the file is not enough.
+Patchelf utility not less than version 0.9 should be used to change internal SONAME field:
+
+```
+patchelf --set-soname libsynmozjs52.so libmozjs-52.so
+mv libmozjs-52.so libsynmozjs52.so
+```
+
+It is recommended to copy resulting libsynmozjs52.so file to `/usr/lib` directory

--- a/SyNode/mozjs/BuildInstructionSM52.md
+++ b/SyNode/mozjs/BuildInstructionSM52.md
@@ -78,3 +78,4 @@ Then we can run build
     mozmake.exe
 
 After successfully build binary files will be located in `dist\bin` folder. We need to take all `*.dll` from here.
+In order to be aligned with Linux version, the name of the mozjs-52.dll file should be changed to synmozjs52.dll


### PR DESCRIPTION
To avoid conflicts with a packaged (available in atp, yum etc.) version of  libmozjs-52 library patched version of SpiderMonkey library renamed to synmozjs52.dll / libsynmozjs52.so