### PR TITLE
Support for XE4 for SynTaskDialog4Lazarus

### DIFF
--- a/SQLite3/Samples/ThirdPartyDemos/Ondrej/SynTaskDialog4Lazarus/FMXUtil.inc.pas
+++ b/SQLite3/Samples/ThirdPartyDemos/Ondrej/SynTaskDialog4Lazarus/FMXUtil.inc.pas
@@ -1,10 +1,57 @@
+{$IF (CompilerVersion <= 25)}
+type
+    //other name of constants in XE4
+    TStyledSettingHelper = record helper for TStyledSetting
+        const Family = TStyledSetting.ssFamily;
+        const Size = TStyledSetting.ssSize;
+        const Style = TStyledSetting.ssStyle;
+        const FontColor = TStyledSetting.ssFontColor;
+        const Other = TStyledSetting.ssOther;
+    end;
+
+    TTextAlignHelper = record helper for TTextAlign
+        const Center = TTextAlign.taCenter;
+        const Leading = TTextAlign.taLeading;
+        const Trailing = TTextAlign.taTrailing;
+    end;
+
+    TFmxFormBorderStyleHelper = record helper for TFmxFormBorderStyle
+        const None = TFmxFormBorderStyle.bsNone;
+        const Single = TFmxFormBorderStyle.bsSingle;
+        const Sizeable = TFmxFormBorderStyle.bsSizeable;
+        const ToolWindow = TFmxFormBorderStyle.bsToolWindow;
+        const SizeToolWin = TFmxFormBorderStyle.bsSizeToolWin;
+    end;
+
+    TFormPositionHelper = record helper for TFormPosition
+        //(poDesigned, poDefault, poDefaultPosOnly, poDefaultSizeOnly,
+        //poScreenCenter, poDesktopCenter, poMainFormCenter, poOwnerFormCenter);
+        const OwnerFormCenter = TFormPosition.poOwnerFormCenter;
+        const ScreenCenter = TFormPosition.poScreenCenter;
+    end;
+
+    TBrushKindHelper = record helper for TBrushKind
+        //(bkNone, bkSolid, bkGradient, bkBitmap, bkResource);
+        const None = TBrushKind.bkNone;
+    end;
+
+    TAlignLayoutHelper = record helper for TAlignLayout
+        //(alNone, alTop, alLeft, alRight, alBottom, alMostTop, alMostBottom, alMostLeft, alMostRight, alClient,
+        //alContents, alCenter, alVertCenter, alHorzCenter, alHorizontal, alVertical, alScale, alFit, alFitLeft, alFitRight);
+        const Top = TAlignLayout.alTop;
+    end;
+
+{$IFEND}
+
 var
   _ScreenDPI_X : Single = 0;
 
 function ScalingByScreenDPI_N( F:TForm = NIL ):Single;
 var
   p : TPointF;
+  {$IF (CompilerVersion >= 28)}
   M : TDeviceDisplayMetrics;
+  {$IFEND}
   i : integer;
   h : THandle;
 begin
@@ -29,6 +76,7 @@ begin
   end;
  {$ENDIF}
 
+  {$IF (CompilerVersion >= 28)}   //TDeviceDisplayMetrics is available since XE8
   if TPlatformServices.Current.SupportsPlatformService( IFMXDeviceMetricsService ) then
   begin
     M := (TPlatformServices.Current.GetPlatformService(
@@ -38,6 +86,7 @@ begin
                                   {$IFDEF MSWINDOWS}96{$ENDIF}
                                   ;
   end;
+  {$IFEND}
 end;
 
 function ScalingByScreenDPI( F:TForm = NIL ):TPointF;

--- a/SQLite3/Samples/ThirdPartyDemos/Ondrej/SynTaskDialog4Lazarus/SynTaskDialog.pas
+++ b/SQLite3/Samples/ThirdPartyDemos/Ondrej/SynTaskDialog4Lazarus/SynTaskDialog.pas
@@ -139,8 +139,12 @@ uses
   {$endif}
   {$IFDEF FMX}
   System.UITypes, System.Types, System.UIConsts,
-  FMX.Menus, FMX.Types, FMX.Layouts, FMX.ComboEdit,
-  FMX.Graphics, FMX.Forms, FMX.Controls, FMX.StdCtrls, FMX.ExtCtrls,
+  FMX.Menus, FMX.Types, FMX.Layouts,
+  {$IF (CompilerVersion >= 26.0)}// Delphi XE5 UP
+  FMX.ComboEdit,
+  FMX.Graphics,
+  {$IFEND}
+  FMX.Forms, FMX.Controls, FMX.StdCtrls, FMX.ExtCtrls,
   FMX.ListBox, FMX.Edit, FMX.Objects, FMX.Platform,
   {$IFDEF MSWINDOWS}
   FMX.Platform.Win


### PR DESCRIPTION
ThirdPartyDemo SynTaskDialog4Lazarus did not compile under XE4/FireMonkey. This patch allows the usage under XE4/FMX. Scaling however will use defaults because of missing functionality in XE4-FMX