### PR TITLE
Fixed a bug in TSQLPropInfoList.InternalAddParentsFirst

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -24238,7 +24238,8 @@ begin
       SetLength(aFlattenedProps,prev);
     end else
       if (pilIgnoreIfGetter in fOptions) and not P^.GetterIsField then
-        continue else
+        // Skip.
+      else
         Add(TSQLPropInfoRTTI.CreateFrom(P,Count,fOptions,aFlattenedProps));
     P := P^.Next;
   end;


### PR DESCRIPTION
Fixed a bug in TSQLPropInfoList.InternalAddParentsFirst which caused all properties to be skipped after a property with a getter is encountered and pilIgnoreIfGetter is in fOptions.