### PR TITLE
Fix encoding in let's TSQLDBZEOSStatement.Prepare use controls_cp=CP_UTF8 feature for…

### DIFF
--- a/SynDBZeos.pas
+++ b/SynDBZeos.pas
@@ -850,7 +850,7 @@ begin
     raise ESQLDBZEOS.CreateUTF8('%.Prepare() shall be called once',[self]);
   inherited Prepare(aSQL,ExpectResults); // connect if necessary
   fStatement := (fConnection as TSQLDBZEOSConnection).fDatabase.
-    PrepareStatementWithParams(UTF8ToString(fSQL),
+    PrepareStatementWithParams({$ifdef UNICODE}UTF8ToString(fSQL){$else}fSQL{$endif}, // see controls_cp=CP_UTF8
     (fConnection.Properties as TSQLDBZEOSConnectionProperties).fStatementParams);
 end;
 


### PR DESCRIPTION
Let's TSQLDBZEOSStatement.Prepare use controls_cp=CP_UTF8 feature fo non-Unicode compiler (FPC)
In other case query like
```
comment on table myTable is 'non-latin-chars-here'
```
failed with message `Invalid byte sequence for encoding "UTF8"` under FPC