### PR TITLE
Add dynlibs in SynGSSAPI.pas to cross-compile in Lazarus + FPC stable

### DIFF
--- a/SynGSSAPI.pas
+++ b/SynGSSAPI.pas
@@ -59,7 +59,8 @@ interface
 
 uses
   SysUtils,
-  Classes;
+  Classes
+  {$ifdef LINUX},dynlibs{$endif};
 
 type
   {$ifdef HASCODEPAGE}


### PR DESCRIPTION
Dont compile in:
Lazarus (Win64): 1.8.2 (stable)
FPC: 3.0.4 (stable)
Cross-compiling to Linux x86_64

Without dynlibs in uses.