### PR TITLE
Linux compatibility fix

### DIFF
--- a/SynZip.pas
+++ b/SynZip.pas
@@ -1473,8 +1473,12 @@ var Parent: TFileName;
 begin
   result := false;
   if Path='' then exit;
+  {$IFDEF FPC}
+  Path := IncludeTrailingPathDelimiter(SetDirSeparators(Path));
+  {$ELSE} // We assume Delphi for Windows here
   if Path[length(Path)]<>'\' then
     Path := Path+'\';
+  {$ENDIF}
   if DirectoryExists(Path) then
     result := true else begin
     Parent := ExtractFilePath(system.copy(Path,1,length(Path)-1));


### PR DESCRIPTION
This fixes directory support in SynZip - forces correct direction of slashes (forward <-> backward), depending on OS a program is running on