### PR TITLE
Fix to build with current trunk fpc

### DIFF
--- a/SyNode/core_modules/core_modules
+++ b/SyNode/core_modules/core_modules
@@ -1,0 +1,1 @@
+../../../../../libs/Synopse/SyNode/core_modules


### PR DESCRIPTION
This small change is required to build mORMot with the latest trunk fpc compiler