### PR TITLE
XE5 and higher FireDAC DriverID for firebird definition fix

### DIFF
--- a/SynDBDataset/SynDBFireDAC.pas
+++ b/SynDBDataset/SynDBFireDAC.pas
@@ -206,10 +206,14 @@ type
 
 const
   /// FireDAC DriverID values corresponding to SynDB recognized SQL engines
+  {$ifdef ISDELPHIXE5}
+  FIREDAC_PROVIDER: array[dOracle..high(TSQLDBDefinition)] of RawUTF8 = (
+    'Ora','MSSQL','MSAcc','MySQL','SQLite','FB','','PG','DB2','Infx');
+
+  {$else}
   FIREDAC_PROVIDER: array[dOracle..high(TSQLDBDefinition)] of RawUTF8 = (
     'Ora','MSSQL','MSAcc','MySQL','SQLite','IB','','PG','DB2','Infx');
-
-
+  {$endif}
 implementation
 
 uses


### PR DESCRIPTION
In Tokyo 10.2.3 server crashes if  choise firebird driver id. Correct definition of driver id is 'FB' for firebird.