### PR TITLE
Fix for FPC 3.3.1 (TVmtMethodParam.Name is property)

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -56282,7 +56282,9 @@ begin
             Args[n-1]:=Args[n];
             SetLength(Args,n);
           end else
-            ParamName := @VMP^.Name;
+            { Since https://svn.freepascal.org/cgi-bin/viewvc.cgi?view=revision&revision=39684 ,
+              we cannot take an address of TVmtMethodParam.Name , we have to use NamePtr instead. }
+            ParamName := {$ifdef VER3_1} @VMP^.Name {$else} VMP^.NamePtr {$endif};
         end;
         Inc(paramcounter);
         Inc(argsindex);


### PR DESCRIPTION
Out of curiosity, I was just testing latest FPC 3.3.1 (SVN revision 39838, from today), and found that mORMot doesn't compile with it.

`TVmtMethodParam.Name` is a property (even using a function as a getter) since the FPC commit 39684 (see https://svn.freepascal.org/cgi-bin/viewvc.cgi?view=revision&revision=39684 , https://github.com/graemeg/freepascal/commit/1fba32c898150edaccead4ce54f40cda56983f02 ). Previously `TVmtMethodParam.Name` was a simple field.

This means that doing `ParamName := @VMP^.Name;` no longer compiles, since `Name` is no longer a simple variable.

Using `ParamName := VMP^.NamePtr;` is the solution. However `NamePtr` doesn't exist before this commit.

The proposed change uses `@VMP^.Name` for FPC 3.1.1, otherwise it assumes it's a recent version of FPC 3.3.1 and uses `NamePtr`. It's far from perfect of course (there are revisions in 3.3.1 before 39684...), but at least all revisions of FPC 3.1.1, *and* the latest and future FPC 3.3.1, will compile OK.

I assume that mORMot doesn't support FPC 3.0.x or earlier, so we do not have to account for that at all in `$ifdefs`.
