### PR TITLE
fix NowUTC time shift to -70 second on FPC x64

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -35526,14 +35526,15 @@ end;
 function NowUTC: TDateTime;
 {$ifdef MSWINDOWS}
 var ft: TFileTime;
-    {$ifdef CPU64}nano100: Int64;{$endif}
+    {$ifdef CPU64}nano100: Int64; d: double;{$endif}
 begin
   GetSystemTimeAsFileTime(ft); // very fast, with 100 ns unit
   {$ifdef CPU64}
   FileTimeToInt64(ft,nano100);
   // in two explicit steps to circumvent weird precision error on FPC
-  result := nano100-DateFileTimeDelta;
-  result := result/(10000000.0*SecsPerDay);
+  // having d: double is important here
+  d := (nano100-DateFileTimeDelta) / 10000000;
+  result := d/SecsPerDay;
   {$else} // use PInt64 to avoid URW699 with Delphi 6 / Kylix
   dec(PInt64(@ft)^,DateFileTimeDelta);
   result := PInt64(@ft)^/(10000000.0*SecsPerDay);

--- a/SynSelfTests.pas
+++ b/SynSelfTests.pas
@@ -4480,6 +4480,18 @@ begin
   assert(tmp='0002-00-00');
 end;
 
+{$ifdef FPC}
+Function _LocalTimeToUniversal(LT: TDateTime;TZOffset: Integer): TDateTime;
+begin
+  if (TZOffset > 0) then
+    Result := LT - EncodeTime(TZOffset div 60, TZOffset mod 60, 0, 0)
+  else if (TZOffset < 0) then
+    Result := LT + EncodeTime(Abs(TZOffset) div 60, Abs(TZOffset) mod 60, 0, 0)
+  else
+    Result := LT;
+end;
+{$endif}
+
 procedure TTestLowLevelCommon.TimeZones;
 var tz: TSynTimeZone;
     d: TTimeZoneData;
@@ -4547,8 +4559,12 @@ begin
     tz.Free;
   end;
   dt := NowUTC;
+  {$ifdef FPC}
+  local := _LocalTimeToUniversal(Now(), - GetLocalTimeOffset);
+  CheckSame(local - dt, 0, 1E-5, 'NowUTC should not shift or truncate time');
+  {$endif}
   sleep(200);
-  Check(not SameValue(dt,NowUTC), 'NowUTC should not truncate time');
+  Check(not SameValue(dt,NowUTC), 'NowUTC should not truncate time to 5 sec resolution');
   {$ifdef MSWINDOWS}
   tz := TSynTimeZone.CreateDefault;
   try


### PR DESCRIPTION
See [this forum thread](https://synopse.info/forum/viewtopic.php?id=4516)
On FPC x64 NowUTC produce dates with ~ -70 sec time shift because of weird precision error on FPC