### PR TITLE
support for non-english resourcestrings, no need to restart an app after change of language, support for build under FMX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ _FOSSIL_
 
 backup/
 .idea/
+*.bak

--- a/SQLite3/mORMoti18n.pas
+++ b/SQLite3/mORMoti18n.pas
@@ -2261,7 +2261,7 @@ begin
   if (PtrInt(lpszType)<>PtrInt(RT_STRING)) then exit;
   i := (PtrInt(lpszName)-1)shl 4;
   for i := i to i+15 do begin // resourcestrings are stored by groups of 16
-    SetString(s,buf,LoadStringW(hInstance,i,buf,sizeof(buf)));
+    s := RawUnicodeToUtf8(buf,LoadStringW(hInstance,i,buf,sizeof(buf)));
     if s='' then exit; // we reach the end
     AddOnceDynArray(s);
   end;

--- a/SQLite3/mORMoti18n.pas
+++ b/SQLite3/mORMoti18n.pas
@@ -809,6 +809,11 @@ begin
     result := TLanguages(ndx);
 end;
 
+function Hash32(const Text: RawUTF8): cardinal;
+begin
+  result := SynCommons.Hash32(pointer(Text),length(Text));
+end;
+
 
 const
   // default character set for a specific language (for GUI i18n)
@@ -1931,10 +1936,8 @@ procedure TLanguageFile.Translate(var English: string);
 // case-sensitive (same as standard gettext)
 var result: string;
 begin
-  //resourcestrings may be not in English
   result := FindMessage(Hash32(English)) ;
-    // resourcestring are expected to be in English, that is WinAnsi encoded
- //   {$ifdef UNICODE}StringToWinAnsi{$endif}(English)));
+
   if result<>'' then
     English := result;
 end;
@@ -2229,7 +2232,7 @@ var
 
 function Hash32Str(crc: cardinal; buf: PAnsiChar; len: cardinal): cardinal;
 begin
-  result := Hash32(buf,len);
+  result := SynCommons.Hash32(buf,len);
 end;
 
 function AddOnceDynArray(const S: RawUTF8): integer;

--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -11303,8 +11303,8 @@ function Hash32(Data: pointer; Len: integer): cardinal; overload;
 // - has less colision than Adler32 for short strings
 // - is faster than CRC32 or Adler32, since use DQWord (128 bytes) aligned read
 // - uses RawByteString for binary content hashing, whatever the codepage is
-function Hash32(const Text: RawUTF8): cardinal; overload;
-  {$ifdef HASINLINE}inline;{$endif}
+function Hash32(const Text: RawByteString): cardinal; overload;
+{$ifdef HASINLINE}inline;{$endif}
 
 /// standard Kernighan & Ritchie hash from "The C programming Language", 3rd edition
 // - simple and efficient code, but too much collisions for THasher
@@ -34068,7 +34068,7 @@ begin
   result := result and $ffff;
 end;
 
-function Hash32(const Text: RawUTF8): cardinal;
+function Hash32(const Text: RawByteString): cardinal;
 begin
   result := Hash32(pointer(Text),length(Text));
 end;

--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -11303,7 +11303,7 @@ function Hash32(Data: pointer; Len: integer): cardinal; overload;
 // - has less colision than Adler32 for short strings
 // - is faster than CRC32 or Adler32, since use DQWord (128 bytes) aligned read
 // - uses RawByteString for binary content hashing, whatever the codepage is
-function Hash32(const Text: RawByteString): cardinal; overload;
+function Hash32(const Text: RawUTF8): cardinal; overload;
   {$ifdef HASINLINE}inline;{$endif}
 
 /// standard Kernighan & Ritchie hash from "The C programming Language", 3rd edition
@@ -34068,7 +34068,7 @@ begin
   result := result and $ffff;
 end;
 
-function Hash32(const Text: RawByteString): cardinal;
+function Hash32(const Text: RawUTF8): cardinal;
 begin
   result := Hash32(pointer(Text),length(Text));
 end;


### PR DESCRIPTION
1. Extract non English resourcestrings into .messages files (used rawUTF8 type istead of Ansi)
2. Change language on the fly without restarting an application, many times
- added {$undef USEFORMCREATEHOOK}, to make SetCurrentLanguage procedurę available
- modified procedurę SetCurrentLanguage  
3. some FMXAPP directives in order to be able to build under fmxApplication
 
Sample application
https://github.com/paustr/multiLangApp

