### PR TITLE
ensure interface is assigned to variable (for FPC)

### DIFF
--- a/SynBidirSock.pas
+++ b/SynBidirSock.pas
@@ -3449,8 +3449,9 @@ constructor TAsynchConnections.Create(OnStart, OnStop: TNotifyThreadEvent;
   aStreamClass: TAsynchConnectionClass; const ProcessName: SockString;
   aLog: TSynLogClass; aOptions: TAsynchConnectionsOptions; aThreadPoolCount: integer);
 var i: integer;
+    log: ISynLog;
 begin
-  aLog.Enter('Create(%,%,%)',[aStreamClass,ProcessName,aThreadPoolCount],self);
+  log := aLog.Enter('Create(%,%,%)',[aStreamClass,ProcessName,aThreadPoolCount],self);
   if (aStreamClass=TAsynchConnection) or (aStreamClass=nil) then
     raise EAsynchConnections.CreateUTF8('%.Create(%)',[self,aStreamClass]);
   if aThreadPoolCount<=0 then

--- a/SynDBODBC.pas
+++ b/SynDBODBC.pas
@@ -1239,17 +1239,20 @@ begin
 end;
 
 procedure TODBCConnection.Disconnect;
+var log: ISynLog;
 begin
   try
     inherited Disconnect; // flush any cached statement
   finally
-    if (ODBC<>nil) and (fDbc<>nil) then
+    if (ODBC<>nil) and (fDbc<>nil) then begin
     with ODBC do begin
-      SynDBLog.Enter(self{$ifndef DELPHI5OROLDER},'Disconnect'{$endif});
+      log := SynDBLog.Enter(self{$ifndef DELPHI5OROLDER},'Disconnect'{$endif});
       Disconnect(fDbc);
       FreeHandle(SQL_HANDLE_DBC,fDbc);
       fDbc := nil;
     end;
+    end else
+      log := nil;
   end;
 end;
 

--- a/SynDBODBC.pas
+++ b/SynDBODBC.pas
@@ -1244,15 +1244,13 @@ begin
   try
     inherited Disconnect; // flush any cached statement
   finally
-    if (ODBC<>nil) and (fDbc<>nil) then begin
+    if (ODBC<>nil) and (fDbc<>nil) then
     with ODBC do begin
       log := SynDBLog.Enter(self{$ifndef DELPHI5OROLDER},'Disconnect'{$endif});
       Disconnect(fDbc);
       FreeHandle(SQL_HANDLE_DBC,fDbc);
       fDbc := nil;
     end;
-    end else
-      log := nil;
   end;
 end;
 


### PR DESCRIPTION
Assign Log.Enter result to variable to allow FPC release interface