### PR TITLE
synode base64 decoder optimization

### DIFF
--- a/SyNode/SyNodeBinding_buffer.pas
+++ b/SyNode/SyNodeBinding_buffer.pas
@@ -322,7 +322,7 @@ const
 //   estimatedLength := anyBase64ToBin(str, strLen, nil, strLen);
 function anyBase64ToBin(str: PAnsiChar; strLen: PtrInt;
   bin: PAnsiChar; maxBinLength: PtrInt;
-  strIsTwoBytes: boolean = false; isStrict: boolean = false): PtrInt;
+  strIsTwoBytes: boolean = false): PtrInt;
 var
   maxS, maxB, bPos, sPos: PtrInt;
   v: uint32;


### PR DESCRIPTION
# Fixed
 - Buffer.from(str, 'base64') will work correctly in case `str` is representing as 2-byte string inside SM engine (can happens in case `str` extracted from string with non-latin characters)

# Added
 - Buffer.from(str, 'base64') can decode base64 with wite-spaces inside (for example SOAP XMLs separate long base64 string by \r\n)
 
# Optimized
 - x5 speedup of Buffer.from(str, 'base64') 