### PR TITLE
unmapping memory mapped files for Unix

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -59820,8 +59820,7 @@ begin
     fMap := 0;
   end;
   {$else}
-  if (fBuf<>nil) and (fBufSize>0)
-    {$ifndef KYLIX3} and (fFileSize<>fBufSize){$endif} then
+  if (fBuf<>nil) and (fBufSize>0) then
     {$ifdef KYLIX3}munmap{$else}fpmunmap{$endif}(fBuf,fBufSize);
   {$endif}
   fBuf := nil;


### PR DESCRIPTION
Unix: Memory mapped files must be un-mapped for any non zero buffer size
Without this fix files remains mmaped until process exit