### PR TITLE
TCurlHTTP: remove 1 second delay on non-GET requests

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -11471,7 +11471,9 @@ begin
   curl.easy_setopt(fHandle,coWriteFunction,@CurlWriteRawByteString);
   curl.easy_setopt(fHandle,coHeaderFunction,@CurlWriteRawByteString);
   fIn.Method := UpperCase(method);
-  fIn.Headers := nil;
+  if fIn.Method = 'GET' then
+    fIn.Headers := nil else // disable Expect 100 continue in libcurl
+    fIn.Headers := curl.slist_append(fIn.Headers,'Expect:');
   Finalize(fOut);
 end;
 


### PR DESCRIPTION
When send a POST request using libCURL (TCurlHTTP) a
```
Expect: 100-continue
```
header is adsed by curl to request.

Server should respond with "100" [see MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect) but Socket-based server in mORMot do not handle this header.

Even if we implement 100 response (i already implement) one second delay occurs in case of HTTP1.0 protocol is used.

So the best choice is to add a 'Expect:' header for non GET requests inside TCurlHTTP as in this patch