### PR TITLE
mark TSynLog constructor as virtual

### DIFF
--- a/SynLog.pas
+++ b/SynLog.pas
@@ -869,7 +869,7 @@ type
   public
     /// intialize for a TSynLog class instance
     // - WARNING: not to be called directly! Use Enter or Add class function instead
-    constructor Create(aFamily: TSynLogFamily=nil);
+    constructor Create(aFamily: TSynLogFamily=nil); virtual;
     /// release all memory and internal handles
     destructor Destroy; override;
     /// flush all log content to file


### PR DESCRIPTION
This allow to deeply customize a TSynLog. For example we need to use a custom writer as (described in this blog post](https://synopse.info/forum/viewtopic.php?id=4800) :
```
TubLog = class(TSQLLog)
  public
    constructor Create(aFamily: TSynLogFamily=nil); override;
  end;
...
constructor TubLog.Create(aFamily: TSynLogFamily);
begin
  inherited Create(aFamily);
  fWriterClass := TubLogWriter;
end;
```