### PR TITLE
TextColor - prevent unnecessary syscalls

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -55888,6 +55888,7 @@ begin
   if ord(color)>=8 then
     write(#27'[1;3',AnsiTbl[(ord(color) and 7)+1],'m') else
     write(#27'[0;3',AnsiTbl[(ord(color) and 7)+1],'m');
+  ioresult;
 end;
 {$I+}
 

--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -55886,10 +55886,8 @@ begin
     exit;
   TextAttr := ord(color);
   if ord(color)>=8 then
-    write(#27'[1;3') else
-    write(#27'[0;3');
-  write(AnsiTbl[(ord(color) and 7)+1],'m');
-  ioresult;
+    write(#27'[1;3',AnsiTbl[(ord(color) and 7)+1],'m') else
+    write(#27'[0;3',AnsiTbl[(ord(color) and 7)+1],'m');
 end;
 {$I+}
 


### PR DESCRIPTION
For FPC+Linux every call to write() =  syscall write

Since every syscall is: 
 - atomic
 - expensive

after this patch console coloring become a little bit faster and atomic (calling TextColor from different thread do not brake a terminal commands on 2 part)

(verified using `strace`)
