### PR TITLE
Fixed a bug in TPropInfo.GetVariant handling of tkDynArray.

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -29418,6 +29418,7 @@ end;
 procedure TPropInfo.GetVariant(Instance: TObject; var Dest: variant);
 var i: PtrInt;
     U: RawUTF8;
+    p: Pointer;
 begin
   if (Instance<>nil) and (@self<>nil) then
   case PropType^.Kind of
@@ -29447,8 +29448,10 @@ begin
   tkFloat: Dest := GetFloatProp(Instance);
   tkVariant: GetVariantProp(Instance,Dest);
   tkClass: ObjectToVariant(GetObjProp(Instance),Dest);
-  tkDynArray: TDocVariantData(Dest).InitArrayFromObjArray(
-    pointer(GetOrdProp(Instance))^,JSON_OPTIONS_FAST);
+  tkDynArray: begin
+    p := pointer(GetOrdProp(Instance));
+    TDocVariantData(Dest).InitArrayFromObjArray(p,JSON_OPTIONS_FAST);
+  end
   else VarClear(Dest);
   end;
 end;


### PR DESCRIPTION
Result from GetOrdProp was being erroneously dereferenced before being passed to TDocVariantData.InitArrayFromObjArray.