### PR TITLE
json serializer adds a T00:00Z to dates without time in UTC0

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -52244,7 +52244,9 @@ var Added: boolean;
               Add('"');
             AddDateTime(D64);
             if woDateTimeWithZSuffix in Options then
-              Add('Z');
+              if frac(D64)=0 then // FireFox can't decode short form "2017-01-01Z"
+                AddShort('T00:00Z') else
+                Add('Z');
             Add('"');
           end;
         end else begin


### PR DESCRIPTION
In case woDateTimeWithZSuffix Option is passed to TJSONSerializer and TDateTime value do not contains a time then T00:00Z should be added to the resulting string. 

In other case FireFox and Internet Explorer based client fails to parse
```
new Date('2017-01-01Z')
```
Chromium will