### PR TITLE
FPC fix: incorrect usage of  TPrecisionTimer.ProfileCurrentMethod in SybDBOracle

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -15879,6 +15879,7 @@ type
     // - typical use is to declare a fTimeElapsed: TPrecisionTimer protected
     // member, then call fTimeElapsed.ProfileCurrentMethod at the beginning of
     // all process expecting some timing, then log/save fTimeElapsed.Stop content
+    // FPC TIP: result should be assigned to the local variable of IUnknown type
     function ProfileCurrentMethod: IUnknown;
     /// low-level method to force values settings to allow thread safe timing
     // - by default, this timer is not thread safe: you can use this method to

--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -2540,22 +2540,26 @@ constructor TSQLDBOracleStatement.CreateFromExistingStatement(
   aConnection: TSQLDBConnection; aStatement: POCIStmt);
 begin
   Create(aConnection);
-  fTimeElapsed.ProfileCurrentMethod;
-  fStatement := aStatement;
+  with fTimeElapsed do if Started then Resume else Start;
   try
-    fExpectResults := true;
-    SetColumnsForPreparedStatement;
-    FetchRows;
-    if fRowFetched=0 then
-      fCurrentRow := -1 else // no data row available
-      fCurrentRow := 0; // mark cursor on the first row
-  except
-    on E: Exception do begin
-      SynDBLog.Add.Log(sllError,E);
-      fStatement := nil; // do not release the statement in constructor
-      FreeHandles(True);
-      raise;
+    fStatement := aStatement;
+    try
+      fExpectResults := true;
+      SetColumnsForPreparedStatement;
+      FetchRows;
+      if fRowFetched=0 then
+        fCurrentRow := -1 else // no data row available
+        fCurrentRow := 0; // mark cursor on the first row
+    except
+      on E: Exception do begin
+        SynDBLog.Add.Log(sllError,E);
+        fStatement := nil; // do not release the statement in constructor
+        FreeHandles(True);
+        raise;
+      end;
     end;
+  finally
+    fTimeElapsed.Pause;
   end;
 end;
 
@@ -2678,300 +2682,304 @@ begin
       tmp := SQLWithInlinedParams;
       Log(sllSQL,tmp,self,2048);
     end;
-  fTimeElapsed.ProfileCurrentMethod;
-  ociArraysCount := 0;
-  Env := (Connection as TSQLDBOracleConnection).fEnv;
-  Context := TSQLDBOracleConnection(Connection).fContext;
-  Status := OCI_ERROR;
+  with fTimeElapsed do if Started then Resume else Start;
   try
-    fRowFetchedEnded := false;
-    // 1. bind parameters
-    if fPreparedParamsCount<>fParamCount then
-      raise ESQLDBOracle.CreateUTF8('%.ExecutePrepared expected % bound parameters, got %',
-        [self,fPreparedParamsCount,fParamCount]);
-    if not fExpectResults then
-      fRowCount := 1; // to avoid ORA-24333 error
-    if (fParamCount>0) then
-    if (fParamsArrayCount>0) and not fExpectResults then begin
-      // 1.1. Array DML binding
-      SetLength(aIndicator,fParamCount);
-      for i := 0 to fParamCount-1 do
-      with fParams[i] do begin
-        if VArray=nil then
-          raise ESQLDBOracle.CreateUTF8(
-            '%.ExecutePrepared: Parameter #% should be an array',[self,i]);
-        if VInt64<>fParamsArrayCount then
-          raise ESQLDBOracle.CreateUTF8(
-            '%.ExecutePrepared: Parameter #% expected array count %, got %',
-            [self,i,fParamsArrayCount,VInt64]);
-        SetLength(aIndicator[i],fParamsArrayCount);
-        VDBType := SQLT_STR;
-        oLength := 23; // max size for ftInt64/ftDouble/ftCurrency
-        case VType of
-        ftDate: begin
-          VDBType := SQLT_DAT;
-          SetString(VData,nil,fParamsArrayCount*sizeof(TOracleDate));
-          oData := pointer(VData);
-          oLength := sizeof(TOracleDate);
-        end;
-        ftInt64:
-          if OCI.SupportsInt64Params then begin
-            // starting with 11.2, OCI supports NUMBER conversion to/from Int64
-            VDBType := SQLT_INT;
-            SetString(VData,nil,fParamsArrayCount*sizeof(Int64));
-            oData := pointer(VData);
-            oLength := sizeof(Int64);
-          end; // prior to 11.2, we will stay with the default SQLT_STR type
-        ftUTF8:
-          oLength := 7; // minimal aligned length
-        ftBlob: begin
-          VDBTYPE := SQLT_LVB;
-          oLength := 7; // minimal aligned length
-        end;
-        end;
-        for j := 0 to fParamsArrayCount-1 do
-          if VArray[j]='null' then // bind null (ftUTF8 should be '"null"')
-            aIndicator[i][j] := -1 else begin
-            if VDBType=SQLT_INT then
-              SetInt64(pointer(Varray[j]),oDataINT^[j]) else
-            case VType of
-            ftUTF8,ftDate: begin
-              L := length(VArray[j])-2; // -2 since quotes will be removed
-              if VType=ftDate then
-                if L<=0 then
-                  oDataDAT^[j].From(0) else
-                  oDataDAT^[j].From(PUTF8Char(pointer(VArray[j]))+1,L) else
-                if L>oLength then
-                  if L*fParamsArrayCount>MAX_INLINED_PARAM_SIZE then
-                    raise ESQLDBOracle.CreateUTF8(
-                      '%.ExecutePrepared: Array parameter #% STR too big',[self,i+1]) else
-                    oLength := L;
-            end;
-            ftBlob: begin
-              L := length(VArray[j])+sizeof(integer);
-              if L*fParamsArrayCount>MAX_INLINED_PARAM_SIZE then
-                raise ESQLDBOracle.CreateUTF8(
-                  '%.ExecutePrepared: Array parameter #% BLOB too big',[self,i+1]) else
-              if L>oLength then
-                oLength := L;
-            end;
-            end;
-          end;
-        case VDBType of
-        SQLT_STR: begin
-          inc(oLength); // space for trailing #0
-          SetString(VData,nil,oLength*fParamsArrayCount);
-          oData := Pointer(VData); // in-place quote removal in text
-          oDataSTR := oData;
-          for j := 0 to fParamsArrayCount-1 do begin
-            UnQuoteSQLString(pointer(VArray[j]),oDataSTR,length(VArray[j]));
-            inc(oDataSTR,oLength);
-          end;
-        end;
-        SQLT_LVB: begin
-          SetString(VData,nil,oLength*fParamsArrayCount);
-          oData := Pointer(VData);
-          oDataSTR := oData;
-          for j := 0 to fParamsArrayCount-1 do begin
-            {$ifdef FPC}
-            PInteger(oDataSTR)^ := length(VArray[j]);
-            MoveFast(Pointer(VArray[j])^,oDataSTR[4],length(VArray[j]));
-            {$else}
-            MoveFast(Pointer(PtrInt(VArray[j])-4)^,oDataSTR^,length(VArray[j])+4);
-            {$endif}
-            inc(oDataSTR,oLength);
-          end;
-        end;
-        end;
-        oBind := nil;
-        OCI.Check(nil,self,OCI.BindByPos(fStatement,oBind,fError,i+1,oData,oLength,VDBType,
-          pointer(aIndicator[i]),nil,nil,0,nil,OCI_DEFAULT),fError);
-      end;
-      fRowCount := fParamsArrayCount; // set iters count for OCI.StmtExecute()
-    end else begin
-      // 1.2. One row DML optimized binding
-      FillcharFast(Int32,sizeof(Int32),0);
-      SetLength(oIndicator,fParamCount);
-      SetLength(ociArrays,fParamCount);
-      for i := 0 to fParamCount-1 do
-      if Length(fParams[i].VArray)>0 then begin
-        // 1.2.1. Bind an array as one object
-        case fParams[i].VType of
-        ftInt64:
-          Type_List := TSQLDBOracleConnection(Connection).fType_numList;
-        ftUTF8:
-          Type_List := TSQLDBOracleConnection(Connection).fType_strList;
-        else
-          Type_List := nil;
-        end;
-        if Type_List=nil then
-         raise ESQLDBOracle.CreateUTF8(
-            '%.ExecutePrepared: Unsupported array parameter type #%',[self,i+1]);
-        ociArrays[ociArraysCount] := nil;
-        OCI.Check(nil,self,OCI.ObjectNew(Env, fError, Context, OCI_TYPECODE_VARRAY, Type_List, nil,
-          OCI_DURATION_SESSION, True, ociArrays[ociArraysCount]), fError);
-        inc(ociArraysCount);
-        SetString(fParams[i].VData,nil,Length(fParams[i].VArray)*sizeof(Int64));
-        oData := pointer(fParams[i].VData);
-        for j := 0 to Length(fParams[i].VArray)-1 do
-          case fParams[i].VType of
-          ftInt64: begin
-            SetInt64(pointer(fParams[i].Varray[j]),oDataINT^[j]);
-            OCI.Check(nil,self,OCI.NumberFromInt(fError, @oDataINT[j], sizeof(Int64), OCI_NUMBER_SIGNED, num_val), fError);
-            OCI.Check(nil,self,OCI.CollAppend(Env, fError, @num_val, nil, ociArrays[ociArraysCount-1]),fError);
-          end;
-          ftUTF8: begin
-            str_val := nil;
-            SynCommons.UnQuoteSQLStringVar(pointer(fParams[i].VArray[j]),tmp);
-            OCI.Check(nil,self,OCI.StringAssignText(Env, fError, pointer(tmp), length(tmp), str_val), fError);
-            OCI.Check(nil,self,OCI.CollAppend(Env, fError, str_val, nil, ociArrays[ociArraysCount-1]),fError);
-          end;
-          end;
-        oBind := nil;
-        OCI.Check(nil,self,OCI.BindByPos(fStatement,oBind,fError,i+1,nil,0,SQLT_NTY,
-          nil,nil,nil,0,nil,OCI_DEFAULT),fError);
-        OCI.BindObject(oBind,fError,Type_List, ociArrays[ociArraysCount-1], nil, nil, nil);
-      end else
-      // 1.2.2. Bind one simple parameter value
-      with fParams[i] do begin
-        if VType=ftNull then begin
-          oIndicator[i] := -1; // assign a NULL to the column, ignoring input value
-          oLength := 0;
-          oData := nil;
+    ociArraysCount := 0;
+    Env := (Connection as TSQLDBOracleConnection).fEnv;
+    Context := TSQLDBOracleConnection(Connection).fContext;
+    Status := OCI_ERROR;
+    try
+      fRowFetchedEnded := false;
+      // 1. bind parameters
+      if fPreparedParamsCount<>fParamCount then
+        raise ESQLDBOracle.CreateUTF8('%.ExecutePrepared expected % bound parameters, got %',
+          [self,fPreparedParamsCount,fParamCount]);
+      if not fExpectResults then
+        fRowCount := 1; // to avoid ORA-24333 error
+      if (fParamCount>0) then
+      if (fParamsArrayCount>0) and not fExpectResults then begin
+        // 1.1. Array DML binding
+        SetLength(aIndicator,fParamCount);
+        for i := 0 to fParamCount-1 do
+        with fParams[i] do begin
+          if VArray=nil then
+            raise ESQLDBOracle.CreateUTF8(
+              '%.ExecutePrepared: Parameter #% should be an array',[self,i]);
+          if VInt64<>fParamsArrayCount then
+            raise ESQLDBOracle.CreateUTF8(
+              '%.ExecutePrepared: Parameter #% expected array count %, got %',
+              [self,i,fParamsArrayCount,VInt64]);
+          SetLength(aIndicator[i],fParamsArrayCount);
           VDBType := SQLT_STR;
-        end else begin
-          oLength := sizeof(Int64);
-          oData := @VInt64;
+          oLength := 23; // max size for ftInt64/ftDouble/ftCurrency
           case VType of
-          ftUnknown: begin
-            if VInOut=paramIn then
-              raise ESQLDBOracle.CreateUTF8(
-                '%.ExecutePrepared: Unexpected IN cursor parameter #%',[self,i+1]);
-            VDBType := SQLT_RSET;
-            with OCI do
-              Check(nil,self,HandleAlloc(Env,PPointer(oData)^,OCI_HTYPE_STMT,0,nil),fError);
-            oLength := sizeof(pointer);
+          ftDate: begin
+            VDBType := SQLT_DAT;
+            SetString(VData,nil,fParamsArrayCount*sizeof(TOracleDate));
+            oData := pointer(VData);
+            oLength := sizeof(TOracleDate);
           end;
           ftInt64:
-            if OCI.SupportsInt64Params then
+            if OCI.SupportsInt64Params then begin
               // starting with 11.2, OCI supports NUMBER conversion to/from Int64
-              VDBType := SQLT_INT else
-              // before 11.2, we will use either SQLT_INT, SQLT_STR or SQLT_FLT
-              if VInOut=paramIn then
-                if (VInt64>low(integer)) and (VInt64<high(Integer)) then begin
-                  // map to 32 bit will always work
-                  VDBType := SQLT_INT;
-                  Include(Int32,i);
-                  oLength := SizeOf(integer); // truncate to 32 bit integer value
-                end else begin
-                  VData := Int64ToUtf8(VInt64);      // (SQLT_VNU did not work)
-                  goto txt; // IN huge integers will be managed as text
-                end else begin
-                VDBType := SQLT_FLT; // OUT values will be converted as double
-                PDouble(oData)^ := VInt64;
+              VDBType := SQLT_INT;
+              SetString(VData,nil,fParamsArrayCount*sizeof(Int64));
+              oData := pointer(VData);
+              oLength := sizeof(Int64);
+            end; // prior to 11.2, we will stay with the default SQLT_STR type
+          ftUTF8:
+            oLength := 7; // minimal aligned length
+          ftBlob: begin
+            VDBTYPE := SQLT_LVB;
+            oLength := 7; // minimal aligned length
+          end;
+          end;
+          for j := 0 to fParamsArrayCount-1 do
+            if VArray[j]='null' then // bind null (ftUTF8 should be '"null"')
+              aIndicator[i][j] := -1 else begin
+              if VDBType=SQLT_INT then
+                SetInt64(pointer(Varray[j]),oDataINT^[j]) else
+              case VType of
+              ftUTF8,ftDate: begin
+                L := length(VArray[j])-2; // -2 since quotes will be removed
+                if VType=ftDate then
+                  if L<=0 then
+                    oDataDAT^[j].From(0) else
+                    oDataDAT^[j].From(PUTF8Char(pointer(VArray[j]))+1,L) else
+                  if L>oLength then
+                    if L*fParamsArrayCount>MAX_INLINED_PARAM_SIZE then
+                      raise ESQLDBOracle.CreateUTF8(
+                        '%.ExecutePrepared: Array parameter #% STR too big',[self,i+1]) else
+                      oLength := L;
               end;
-          ftDouble:
-            VDBType := SQLT_FLT;
-          ftCurrency:
-            if VInOut=paramIn then begin
-              VData := Curr64ToStr(VInt64);
-              goto txt; // input-only currency values will be managed as text
-            end else begin
-              VDBType := SQLT_FLT; // OUT values will be converted as double
-              PDouble(oData)^ := PCurrency(oData)^;
+              ftBlob: begin
+                L := length(VArray[j])+sizeof(integer);
+                if L*fParamsArrayCount>MAX_INLINED_PARAM_SIZE then
+                  raise ESQLDBOracle.CreateUTF8(
+                    '%.ExecutePrepared: Array parameter #% BLOB too big',[self,i+1]) else
+                if L>oLength then
+                  oLength := L;
+              end;
+              end;
             end;
-          ftDate:
-            if VInOut=paramIn then begin
-              VDBType := SQLT_TIMESTAMP; // SQLT_DAT is wrong within WHERE clause
-              oOCIDateTime := DateTimeToDescriptor(PDateTime(@VInt64)^);
-              SetString(VData,PAnsiChar(@oOCIDateTime),sizeof(oOCIDateTime));
-              oData := pointer(VData);
-              oLength := sizeof(oOCIDateTime);
-            end else begin
-              VDBType := SQLT_DAT;  // will work for OUT parameters
-              POracleDate(@VInt64)^.From(PDateTime(@VInt64)^);
-            end;
-          ftUTF8: begin
-  txt:      VDBType := SQLT_STR; // use STR external data type (SQLT_LVC fails)
-            oLength := Length(VData)+1; // include #0
-            if oLength=1 then // '' will just map one #0
-              oData := @VData else
-              oData := pointer(VData);
-            // for OUT param, input text shall be pre-allocated
-          end;
-          ftBlob:
-            if VInOut<>paramIn then
-              raise ESQLDBOracle.CreateUTF8(
-                '%.ExecutePrepared: Unexpected OUT blob parameter #%',[self,i+1]) else begin
-            oLength := Length(VData);
-            if oLength<2000 then begin
-              VDBTYPE := SQLT_BIN;
-              oData := pointer(VData);
-            end else begin
-              VDBTYPE := SQLT_LVB;
-              oData := Pointer(PtrInt(VData)-sizeof(Integer));
-              Inc(oLength,sizeof(Integer));
+          case VDBType of
+          SQLT_STR: begin
+            inc(oLength); // space for trailing #0
+            SetString(VData,nil,oLength*fParamsArrayCount);
+            oData := Pointer(VData); // in-place quote removal in text
+            oDataSTR := oData;
+            for j := 0 to fParamsArrayCount-1 do begin
+              UnQuoteSQLString(pointer(VArray[j]),oDataSTR,length(VArray[j]));
+              inc(oDataSTR,oLength);
             end;
           end;
-          else
-            raise ESQLDBOracle.CreateUTF8(
-              '%.ExecutePrepared: Invalid parameter #% type=%',[self,i+1,ord(VType)]);
+          SQLT_LVB: begin
+            SetString(VData,nil,oLength*fParamsArrayCount);
+            oData := Pointer(VData);
+            oDataSTR := oData;
+            for j := 0 to fParamsArrayCount-1 do begin
+              {$ifdef FPC}
+              PInteger(oDataSTR)^ := length(VArray[j]);
+              MoveFast(Pointer(VArray[j])^,oDataSTR[4],length(VArray[j]));
+              {$else}
+              MoveFast(Pointer(PtrInt(VArray[j])-4)^,oDataSTR^,length(VArray[j])+4);
+              {$endif}
+              inc(oDataSTR,oLength);
+            end;
           end;
+          end;
+          oBind := nil;
+          OCI.Check(nil,self,OCI.BindByPos(fStatement,oBind,fError,i+1,oData,oLength,VDBType,
+            pointer(aIndicator[i]),nil,nil,0,nil,OCI_DEFAULT),fError);
         end;
-        oBind := nil;
-        OCI.Check(nil,self,OCI.BindByPos(fStatement,oBind,fError,i+1,oData,oLength,
-          VDBType,@oIndicator[i],nil,nil,0,nil,OCI_DEFAULT),fError);
+        fRowCount := fParamsArrayCount; // set iters count for OCI.StmtExecute()
+      end else begin
+        // 1.2. One row DML optimized binding
+        FillcharFast(Int32,sizeof(Int32),0);
+        SetLength(oIndicator,fParamCount);
+        SetLength(ociArrays,fParamCount);
+        for i := 0 to fParamCount-1 do
+        if Length(fParams[i].VArray)>0 then begin
+          // 1.2.1. Bind an array as one object
+          case fParams[i].VType of
+          ftInt64:
+            Type_List := TSQLDBOracleConnection(Connection).fType_numList;
+          ftUTF8:
+            Type_List := TSQLDBOracleConnection(Connection).fType_strList;
+          else
+            Type_List := nil;
+          end;
+          if Type_List=nil then
+           raise ESQLDBOracle.CreateUTF8(
+              '%.ExecutePrepared: Unsupported array parameter type #%',[self,i+1]);
+          ociArrays[ociArraysCount] := nil;
+          OCI.Check(nil,self,OCI.ObjectNew(Env, fError, Context, OCI_TYPECODE_VARRAY, Type_List, nil,
+            OCI_DURATION_SESSION, True, ociArrays[ociArraysCount]), fError);
+          inc(ociArraysCount);
+          SetString(fParams[i].VData,nil,Length(fParams[i].VArray)*sizeof(Int64));
+          oData := pointer(fParams[i].VData);
+          for j := 0 to Length(fParams[i].VArray)-1 do
+            case fParams[i].VType of
+            ftInt64: begin
+              SetInt64(pointer(fParams[i].Varray[j]),oDataINT^[j]);
+              OCI.Check(nil,self,OCI.NumberFromInt(fError, @oDataINT[j], sizeof(Int64), OCI_NUMBER_SIGNED, num_val), fError);
+              OCI.Check(nil,self,OCI.CollAppend(Env, fError, @num_val, nil, ociArrays[ociArraysCount-1]),fError);
+            end;
+            ftUTF8: begin
+              str_val := nil;
+              SynCommons.UnQuoteSQLStringVar(pointer(fParams[i].VArray[j]),tmp);
+              OCI.Check(nil,self,OCI.StringAssignText(Env, fError, pointer(tmp), length(tmp), str_val), fError);
+              OCI.Check(nil,self,OCI.CollAppend(Env, fError, str_val, nil, ociArrays[ociArraysCount-1]),fError);
+            end;
+            end;
+          oBind := nil;
+          OCI.Check(nil,self,OCI.BindByPos(fStatement,oBind,fError,i+1,nil,0,SQLT_NTY,
+            nil,nil,nil,0,nil,OCI_DEFAULT),fError);
+          OCI.BindObject(oBind,fError,Type_List, ociArrays[ociArraysCount-1], nil, nil, nil);
+        end else
+        // 1.2.2. Bind one simple parameter value
+        with fParams[i] do begin
+          if VType=ftNull then begin
+            oIndicator[i] := -1; // assign a NULL to the column, ignoring input value
+            oLength := 0;
+            oData := nil;
+            VDBType := SQLT_STR;
+          end else begin
+            oLength := sizeof(Int64);
+            oData := @VInt64;
+            case VType of
+            ftUnknown: begin
+              if VInOut=paramIn then
+                raise ESQLDBOracle.CreateUTF8(
+                  '%.ExecutePrepared: Unexpected IN cursor parameter #%',[self,i+1]);
+              VDBType := SQLT_RSET;
+              with OCI do
+                Check(nil,self,HandleAlloc(Env,PPointer(oData)^,OCI_HTYPE_STMT,0,nil),fError);
+              oLength := sizeof(pointer);
+            end;
+            ftInt64:
+              if OCI.SupportsInt64Params then
+                // starting with 11.2, OCI supports NUMBER conversion to/from Int64
+                VDBType := SQLT_INT else
+                // before 11.2, we will use either SQLT_INT, SQLT_STR or SQLT_FLT
+                if VInOut=paramIn then
+                  if (VInt64>low(integer)) and (VInt64<high(Integer)) then begin
+                    // map to 32 bit will always work
+                    VDBType := SQLT_INT;
+                    Include(Int32,i);
+                    oLength := SizeOf(integer); // truncate to 32 bit integer value
+                  end else begin
+                    VData := Int64ToUtf8(VInt64);      // (SQLT_VNU did not work)
+                    goto txt; // IN huge integers will be managed as text
+                  end else begin
+                  VDBType := SQLT_FLT; // OUT values will be converted as double
+                  PDouble(oData)^ := VInt64;
+                end;
+            ftDouble:
+              VDBType := SQLT_FLT;
+            ftCurrency:
+              if VInOut=paramIn then begin
+                VData := Curr64ToStr(VInt64);
+                goto txt; // input-only currency values will be managed as text
+              end else begin
+                VDBType := SQLT_FLT; // OUT values will be converted as double
+                PDouble(oData)^ := PCurrency(oData)^;
+              end;
+            ftDate:
+              if VInOut=paramIn then begin
+                VDBType := SQLT_TIMESTAMP; // SQLT_DAT is wrong within WHERE clause
+                oOCIDateTime := DateTimeToDescriptor(PDateTime(@VInt64)^);
+                SetString(VData,PAnsiChar(@oOCIDateTime),sizeof(oOCIDateTime));
+                oData := pointer(VData);
+                oLength := sizeof(oOCIDateTime);
+              end else begin
+                VDBType := SQLT_DAT;  // will work for OUT parameters
+                POracleDate(@VInt64)^.From(PDateTime(@VInt64)^);
+              end;
+            ftUTF8: begin
+    txt:      VDBType := SQLT_STR; // use STR external data type (SQLT_LVC fails)
+              oLength := Length(VData)+1; // include #0
+              if oLength=1 then // '' will just map one #0
+                oData := @VData else
+                oData := pointer(VData);
+              // for OUT param, input text shall be pre-allocated
+            end;
+            ftBlob:
+              if VInOut<>paramIn then
+                raise ESQLDBOracle.CreateUTF8(
+                  '%.ExecutePrepared: Unexpected OUT blob parameter #%',[self,i+1]) else begin
+              oLength := Length(VData);
+              if oLength<2000 then begin
+                VDBTYPE := SQLT_BIN;
+                oData := pointer(VData);
+              end else begin
+                VDBTYPE := SQLT_LVB;
+                oData := Pointer(PtrInt(VData)-sizeof(Integer));
+                Inc(oLength,sizeof(Integer));
+              end;
+            end;
+            else
+              raise ESQLDBOracle.CreateUTF8(
+                '%.ExecutePrepared: Invalid parameter #% type=%',[self,i+1,ord(VType)]);
+            end;
+          end;
+          oBind := nil;
+          OCI.Check(nil,self,OCI.BindByPos(fStatement,oBind,fError,i+1,oData,oLength,
+            VDBType,@oIndicator[i],nil,nil,0,nil,OCI_DEFAULT),fError);
+        end;
+      end;
+      // 2. execute prepared statement
+      if (fColumnCount=0) and (Connection.TransactionCount=0) then
+        // for INSERT/UPDATE/DELETE without a transaction: AutoCommit after execution
+        mode := OCI_COMMIT_ON_SUCCESS else
+        // for SELECT or inside a transaction: wait for an explicit COMMIT
+        mode := OCI_DEFAULT;
+      Status := OCI.StmtExecute(TSQLDBOracleConnection(Connection).fContext,
+        fStatement,fError,fRowCount,0,nil,nil,mode);
+      FetchTest(Status); // error + set fRowCount+fCurrentRow+fRowFetchedCurrent
+      Status := OCI_SUCCESS; // mark OK for fBoundCursor[] below
+    finally
+      for i := 0 to ociArraysCount-1 do
+        OCI.Check(nil,self,OCI.ObjectFree(Env, fError, ociArrays[i], OCI_OBJECTFREE_FORCE), fError);
+      // 3. release and/or retrieve OUT bound parameters
+      if fParamsArrayCount>0 then
+      for i := 0 to fParamCount-1 do
+        fParams[i].VData := '' else
+      for i := 0 to fParamCount-1 do
+      with fParams[i] do
+      case VType of
+      ftUnknown:
+        if VInOut=paramOut then
+          if Status=OCI_SUCCESS then begin
+            SetLength(fBoundCursor,fParamCount);
+            fBoundCursor[i] := PPointer(@VInt64)^; // available via BoundCursor()
+          end else // on error, release bound statement resource
+            if OCI.HandleFree(PPointer(@VInt64)^,OCI_HTYPE_STMT)<>OCI_SUCCESS then
+              SynDBLog.Add.Log(sllError,'SQLT_RSET param release');
+      ftInt64:
+        if VDBType=SQLT_FLT then // retrieve OUT integer parameter
+          VInt64 := trunc(PDouble(@VInt64)^);
+      ftCurrency:
+        if VDBType=SQLT_FLT then // retrieve OUT currency parameter
+          PCurrency(@VInt64)^ := PDouble(@VInt64)^;
+      ftDate:
+        case VDBType of
+        SQLT_DAT: // retrieve OUT date parameter
+          PDateTime(@VInt64)^ := POracleDate(@VInt64)^.ToDateTime;
+        SQLT_TIMESTAMP: begin // release OCIDateTime resource
+          oOCIDateTime := PPointer(VData)^;
+          if OCI.DescriptorFree(oOCIDateTime,OCI_DTYPE_TIMESTAMP)<>OCI_SUCCESS then
+            SynDBLog.Add.Log(sllError,'OCI_DTYPE_TIMESTAMP param release');
+          VData := '';
+        end;
+        end;
+      ftUTF8:
+        if VInOut<>paramIn then // retrieve OUT text parameter
+          SetLength(VData,StrLen(pointer(VData)));
       end;
     end;
-    // 2. execute prepared statement
-    if (fColumnCount=0) and (Connection.TransactionCount=0) then
-      // for INSERT/UPDATE/DELETE without a transaction: AutoCommit after execution
-      mode := OCI_COMMIT_ON_SUCCESS else
-      // for SELECT or inside a transaction: wait for an explicit COMMIT
-      mode := OCI_DEFAULT;
-    Status := OCI.StmtExecute(TSQLDBOracleConnection(Connection).fContext,
-      fStatement,fError,fRowCount,0,nil,nil,mode);
-    FetchTest(Status); // error + set fRowCount+fCurrentRow+fRowFetchedCurrent
-    Status := OCI_SUCCESS; // mark OK for fBoundCursor[] below
   finally
-    for i := 0 to ociArraysCount-1 do
-      OCI.Check(nil,self,OCI.ObjectFree(Env, fError, ociArrays[i], OCI_OBJECTFREE_FORCE), fError);
-    // 3. release and/or retrieve OUT bound parameters
-    if fParamsArrayCount>0 then
-    for i := 0 to fParamCount-1 do
-      fParams[i].VData := '' else
-    for i := 0 to fParamCount-1 do
-    with fParams[i] do
-    case VType of
-    ftUnknown:
-      if VInOut=paramOut then
-        if Status=OCI_SUCCESS then begin
-          SetLength(fBoundCursor,fParamCount);
-          fBoundCursor[i] := PPointer(@VInt64)^; // available via BoundCursor()
-        end else // on error, release bound statement resource
-          if OCI.HandleFree(PPointer(@VInt64)^,OCI_HTYPE_STMT)<>OCI_SUCCESS then
-            SynDBLog.Add.Log(sllError,'SQLT_RSET param release');
-    ftInt64:
-      if VDBType=SQLT_FLT then // retrieve OUT integer parameter
-        VInt64 := trunc(PDouble(@VInt64)^);
-    ftCurrency:
-      if VDBType=SQLT_FLT then // retrieve OUT currency parameter
-        PCurrency(@VInt64)^ := PDouble(@VInt64)^;
-    ftDate:
-      case VDBType of
-      SQLT_DAT: // retrieve OUT date parameter
-        PDateTime(@VInt64)^ := POracleDate(@VInt64)^.ToDateTime;
-      SQLT_TIMESTAMP: begin // release OCIDateTime resource
-        oOCIDateTime := PPointer(VData)^;
-        if OCI.DescriptorFree(oOCIDateTime,OCI_DTYPE_TIMESTAMP)<>OCI_SUCCESS then
-          SynDBLog.Add.Log(sllError,'OCI_DTYPE_TIMESTAMP param release');
-        VData := '';
-      end;
-      end;
-    ftUTF8:
-      if VInOut<>paramIn then // retrieve OUT text parameter
-        SetLength(VData,StrLen(pointer(VData)));
-    end;
+    fTimeElapsed.Pause;
   end;
 end;
 
@@ -3345,40 +3353,44 @@ procedure TSQLDBOracleStatement.Prepare(const aSQL: RawUTF8;
 var oSQL: RawUTF8;
     Env: POCIEnv;
 begin
-  fTimeElapsed.ProfileCurrentMethod;
+  with fTimeElapsed do if Started then Resume else Start;
   try
-    if (fStatement<>nil) or (fColumnCount>0) then
-      raise ESQLDBOracle.CreateUTF8('%.Prepare should be called only once',[self]);
-    // 1. process SQL
-    inherited Prepare(aSQL,ExpectResults); // set fSQL + Connect if necessary
-    fPreparedParamsCount := ReplaceParamsByNames(aSQL,oSQL);
-    // 2. prepare statement
-    Env := (Connection as TSQLDBOracleConnection).fEnv;
-    with OCI do begin
-      HandleAlloc(Env,fError,OCI_HTYPE_ERROR);
-      if fUseServerSideStatementCache then begin
-        if StmtPrepare2(TSQLDBOracleConnection(Connection).fContext,fStatement,
-          fError,pointer(oSQL),length(oSQL),nil,0,OCI_NTV_SYNTAX,OCI_PREP2_CACHE_SEARCHONLY) = OCI_SUCCESS then
-          SynDBLog.Add.Log(sllDebug, 'Statement cache HIT')
-        else begin
-          Check(nil,self,StmtPrepare2(TSQLDBOracleConnection(Connection).fContext,fStatement,
-            fError,pointer(oSQL),length(oSQL),nil,0,OCI_NTV_SYNTAX,OCI_DEFAULT),fError);
-          SynDBLog.Add.Log(sllDebug, 'Statement cache miss');
+    try
+      if (fStatement<>nil) or (fColumnCount>0) then
+        raise ESQLDBOracle.CreateUTF8('%.Prepare should be called only once',[self]);
+      // 1. process SQL
+      inherited Prepare(aSQL,ExpectResults); // set fSQL + Connect if necessary
+      fPreparedParamsCount := ReplaceParamsByNames(aSQL,oSQL);
+      // 2. prepare statement
+      Env := (Connection as TSQLDBOracleConnection).fEnv;
+      with OCI do begin
+        HandleAlloc(Env,fError,OCI_HTYPE_ERROR);
+        if fUseServerSideStatementCache then begin
+          if StmtPrepare2(TSQLDBOracleConnection(Connection).fContext,fStatement,
+            fError,pointer(oSQL),length(oSQL),nil,0,OCI_NTV_SYNTAX,OCI_PREP2_CACHE_SEARCHONLY) = OCI_SUCCESS then
+            SynDBLog.Add.Log(sllDebug, 'Statement cache HIT')
+          else begin
+            Check(nil,self,StmtPrepare2(TSQLDBOracleConnection(Connection).fContext,fStatement,
+              fError,pointer(oSQL),length(oSQL),nil,0,OCI_NTV_SYNTAX,OCI_DEFAULT),fError);
+            SynDBLog.Add.Log(sllDebug, 'Statement cache miss');
+          end;
+        end else begin
+          HandleAlloc(Env,fStatement,OCI_HTYPE_STMT);
+          Check(nil,self,StmtPrepare(fStatement,fError,pointer(oSQL),length(oSQL),
+            OCI_NTV_SYNTAX,OCI_DEFAULT),fError);
         end;
-      end else begin
-        HandleAlloc(Env,fStatement,OCI_HTYPE_STMT);
-        Check(nil,self,StmtPrepare(fStatement,fError,pointer(oSQL),length(oSQL),
-          OCI_NTV_SYNTAX,OCI_DEFAULT),fError);
+      end;
+      // 3. retrieve column information and dispatch data in row buffer
+      SetColumnsForPreparedStatement;
+    except
+      on E: Exception do begin
+        SynDBLog.Add.Log(sllError,E);
+        FreeHandles(True);
+        raise;
       end;
     end;
-    // 3. retrieve column information and dispatch data in row buffer
-    SetColumnsForPreparedStatement;
-  except
-    on E: Exception do begin
-      SynDBLog.Add.Log(sllError,E);
-      FreeHandles(True);
-      raise;
-    end;
+  finally
+    fTimeElapsed.Pause;
   end;
 end;
 


### PR DESCRIPTION
If result of `TPrecisionTimer.ProfileCurrentMethod` is not assigned to the local variable FPC destroy IUnknown immediately. 
So for FPC we should either create a local IUnknown var, or not use a .ProfileCurrentMethod at all. 
The second is better - in this case we do not create an unnecessary `TPrecisionTimerProfiler` class instance  