### PR TITLE
prevent implicitly connection opening inside TSQLDBZEOSConection constructor

### DIFF
--- a/SynDBZeos.pas
+++ b/SynDBZeos.pas
@@ -772,10 +772,6 @@ begin
   inherited Create(aProperties);
   url := (fProperties as TSQLDBZEOSConnectionProperties).fURL;
   fDatabase := DriverManager.GetConnectionWithParams(url.URL,url.Properties);
-  fDatabase.SetReadOnly(false);
-  // about transactions, see https://synopse.info/forum/viewtopic.php?id=2209
-  fDatabase.SetAutoCommit(true);
-  fDatabase.SetTransactionIsolation(tiReadCommitted);
 end;
 
 procedure TSQLDBZEOSConnection.Connect;
@@ -788,7 +784,13 @@ begin
     Log := SynDBLog.Enter(Self,pointer(FormatUTF8('Connect to % % for % at %:%',
       [Protocol,Database,HostName,Port])),true);
   try
+    // about transactions, see https://synopse.info/forum/viewtopic.php?id=2209
+    // two statement below do not require DB to be connected, so can be before Open
+    fDatabase.SetAutoCommit(true);
+    fDatabase.SetTransactionIsolation(tiReadCommitted);
     fDatabase.Open;
+    fDatabase.SetReadOnly(false);
+
     Log.Log(sllDB,'Connected to % using % %',
       [fProperties.ServerName,fProperties.DatabaseName,fDatabase.GetClientVersion]);
     inherited Connect; // notify any re-connection


### PR DESCRIPTION
Call to `fDatabase.SetReadOnly(false)` will implicitly set `fDatabase.isOpened` to true, so `TSQLDBZEOSConection.Connect` is never called.

This issue introduced in 2014 [6b712a4a] 

The problem solved: I have overrided  `TSQLDBZEOSConection.Connect` method what execute some statements just after connection, for example `set search_path to bla-bla` for Postgres.

Without this modification `TSQLDBZEOSConection.Connect` is never called (at last for Postgres)