### PR TITLE
Update SynCrtSock.pas

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -11716,7 +11716,7 @@ begin
       on E: Exception do begin
         if curl.Module<>0 then
           FreeLibrary(curl.Module);
-        curl.Module := {$ifdef KYLIX3}THandle{$endif}(-1); // don't try to load any more
+        curl.Module := {$ifdef KYLIX3}THandle{$endif}(0); // don't try to load any more
         raise;
       end;
     end;


### PR DESCRIPTION
Don't compile under Delphi 10.3 Rio.
[dcc32 Error] SynCrtSock.pas(11489): E1012 Constant expression violates subrange bounds

PS: I know Curl should be used in Linux.
But I'm coding in Delphi and then generating the final version on Lazarus.