### PR TITLE
try to fix non-english exception logging for FPC

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -54393,16 +54393,12 @@ begin
     AddNoJSONEscape(pointer(s),L); // identified as a BLOB content
     exit;
   end;
-  {$ifdef FPC}
-  CodePage := CP_UTF8;
-  {$else}
   if CodePage<0 then
     {$ifdef HASCODEPAGE}
     CodePage := StringCodePage(s);
     {$else}
     CodePage := 0; // TSynAnsiConvert.Engine(0)=CurrentAnsiConvert
     {$endif}
-  {$endif}
   AddAnyAnsiBuffer(pointer(s),L,Escape,CodePage);
 end;
 
@@ -54862,7 +54858,11 @@ begin
     {$ifdef UNICODE}
     AddJSONEscapeW(pointer(s),Length(s));
     {$else}
-    AddAnyAnsiString(s,twJSONEscape,0);
+      {$ifdef ISFPC30}
+      AddAnyAnsiString(s,twJSONEscape,CP_UTF8);
+      {$else}
+      AddAnyAnsiString(s,twJSONEscape,0);
+      {$endif}
     {$endif}
 end;
 

--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -54393,12 +54393,16 @@ begin
     AddNoJSONEscape(pointer(s),L); // identified as a BLOB content
     exit;
   end;
+  {$ifdef FPC}
+  CodePage := CP_UTF8;
+  {$else}
   if CodePage<0 then
     {$ifdef HASCODEPAGE}
     CodePage := StringCodePage(s);
     {$else}
     CodePage := 0; // TSynAnsiConvert.Engine(0)=CurrentAnsiConvert
     {$endif}
+  {$endif}
   AddAnyAnsiBuffer(pointer(s),L,Escape,CodePage);
 end;
 


### PR DESCRIPTION
this patch fix logging of non-english exception text on FPC. Example:
```
program Project1;
uses
  sysutils, SynLog;
begin
  TSynLog.Family.Level := LOG_VERBOSE;
  try
    raise Exception.create('ошибка');
  finally
  end;
end.
```