### PR TITLE
allow to send Content-Type header for request with empty body

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -6687,7 +6687,7 @@ begin
         SockSend(['Content-Encoding: ',OutContentEncoding]);
   end;
   SockSend(['Content-Length: ',length(OutContent)]); // needed even 0
-  if (OutContent<>'') and (OutContentType<>'') and (OutContentType<>HTTP_RESP_STATICFILE) then
+  if (OutContentType<>'') and (OutContentType<>HTTP_RESP_STATICFILE) then
     SockSend(['Content-Type: ',OutContentType]);
 end;
 


### PR DESCRIPTION
This situation is possible, for example, in case I need to send file using reverse proxy and define a custom Content-Type (to bypass nginx mime types table)
For such response I create empty body and write a headers:
```
X-Accel-Redirect: /internal/someblob
```
and set OutContentType := 'my/contettype' 