### PR TITLE
fix SIGSEGV in ToUTF8 function for x64 target

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -24198,16 +24198,15 @@ end;
 
 {$endif DEFINED_INT32TOUTF8}
 
-{$ifndef CPU64} // already implemented by ToUTF8(Value: PtrInt) below
-function ToUTF8(Value: Int64): RawUTF8;
+{$ifdef CPU64}
+function ToUTF8(Value: PtrInt): RawUTF8;
 var tmp: array[0..23] of AnsiChar;
     P: PAnsiChar;
 begin
   P := StrInt64(@tmp[23],Value);
   FastSetString(result,P,@tmp[23]-P);
 end;
-{$endif CPU64}
-
+{$else}
 function ToUTF8(Value: PtrInt): RawUTF8;
 var tmp: array[0..15] of AnsiChar;
     P: PAnsiChar;
@@ -24215,6 +24214,7 @@ begin
   P := StrInt32(@tmp[15],Value);
   FastSetString(result,P,@tmp[15]-P);
 end;
+{$endif}
 
 function UInt32ToUtf8(Value: cardinal): RawUTF8;
 var tmp: array[0..15] of AnsiChar;

--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -24206,7 +24206,7 @@ begin
   P := StrInt64(@tmp[23],Value);
   FastSetString(result,P,@tmp[23]-P);
 end;
-{$endif}
+{$endif CPU64}
 
 function ToUTF8(Value: PtrInt): RawUTF8;
 {$ifdef CPU64}

--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -24198,8 +24198,18 @@ end;
 
 {$endif DEFINED_INT32TOUTF8}
 
-{$ifdef CPU64}
+{$ifndef CPU64} // already implemented by ToUTF8(Value: PtrInt) below
+function ToUTF8(Value: Int64): RawUTF8;
+var tmp: array[0..23] of AnsiChar;
+    P: PAnsiChar;
+begin
+  P := StrInt64(@tmp[23],Value);
+  FastSetString(result,P,@tmp[23]-P);
+end;
+{$endif}
+
 function ToUTF8(Value: PtrInt): RawUTF8;
+{$ifdef CPU64}
 var tmp: array[0..23] of AnsiChar;
     P: PAnsiChar;
 begin
@@ -24207,7 +24217,6 @@ begin
   FastSetString(result,P,@tmp[23]-P);
 end;
 {$else}
-function ToUTF8(Value: PtrInt): RawUTF8;
 var tmp: array[0..15] of AnsiChar;
     P: PAnsiChar;
 begin


### PR DESCRIPTION
for int64 buffer should be 24 char. Program bellow raise SIGSEGV for x64 with optimization level >=2 
```
program Project1;
uses
  SynCommons;
var
  t: TThreadID;
begin
  t := 140737295120128;
  writeln(ToUTF8(t));
end.
```    