### PR TITLE
fix LoadLibrary in SynGSSAPI &  SynWinSock for FPC x64

### DIFF
--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -1776,13 +1776,6 @@ begin
     result := OCI_WE8MSWIN1252;
 end;
 
-{$ifndef MSWINDOWS}
-function SafeLoadLibrary(const aFileName: TFileName): HMODULE;
-begin
- result := LoadLibrary(PAnsiChar(AnsiString(aFileName)));
-end;
-{$endif}
-
 constructor TSQLDBOracleLib.Create;
 const LIBNAME = {$ifdef MSWINDOWS}'oci.dll'{$else}'libclntsh.so'{$endif};
 var P: PPointer;

--- a/SynGSSAPI.pas
+++ b/SynGSSAPI.pas
@@ -351,7 +351,7 @@ type
 implementation
 
 var
-  GSSAPILibrary: {$ifdef FPC}TLibHandle{$else}HModule{$endif};
+  GSSAPILibrary: {$ifdef FPC}TLibHandle{$else}HMODULE{$endif};
 
 /// The macros that test status codes for error conditions. Note that the
 // GSS_ERROR() macro has changed slightly from the V1 GSSAPI so that it now

--- a/SynGSSAPI.pas
+++ b/SynGSSAPI.pas
@@ -351,7 +351,7 @@ type
 implementation
 
 var
-  GSSAPILibrary: THandle;
+  GSSAPILibrary: {$ifdef FPC}TLibHandle{$else}HModule{$endif};
 
 /// The macros that test status codes for error conditions. Note that the
 // GSS_ERROR() macro has changed slightly from the V1 GSSAPI so that it now
@@ -387,7 +387,7 @@ end;
 
 procedure LoadGSSAPI;
 var
-  LibHandle: THandle;
+  LibHandle: {$ifdef FPC}TLibHandle{$else}HMODULE{$endif};
   UseHeimdal: Boolean;
 begin
   if GSSAPILibrary=0 then begin

--- a/SynWinSock.pas
+++ b/SynWinSock.pas
@@ -950,9 +950,9 @@ implementation
 
 var
   SynSockCount: integer;
-  LibHandle: THandle;
-  Libwship6Handle: THandle;
-  LibSecurHandle: THandle;
+  LibHandle: {$ifdef FPC}TLibHandle{$else}THandle{$endif};
+  Libwship6Handle: {$ifdef FPC}TLibHandle{$else}THandle{$endif};
+  LibSecurHandle: {$ifdef FPC}TLibHandle{$else}THandle{$endif};
 
 function IN6_IS_ADDR_UNSPECIFIED(const a: PInAddr6): boolean;
 begin

--- a/SynWinSock.pas
+++ b/SynWinSock.pas
@@ -950,9 +950,9 @@ implementation
 
 var
   SynSockCount: integer;
-  LibHandle: {$ifdef FPC}TLibHandle{$else}THandle{$endif};
-  Libwship6Handle: {$ifdef FPC}TLibHandle{$else}THandle{$endif};
-  LibSecurHandle: {$ifdef FPC}TLibHandle{$else}THandle{$endif};
+  LibHandle: {$ifdef FPC}TLibHandle{$else}HMODULE{$endif};
+  Libwship6Handle: {$ifdef FPC}TLibHandle{$else}HMODULE{$endif};
+  LibSecurHandle: {$ifdef FPC}TLibHandle{$else}HMODULE{$endif};
 
 function IN6_IS_ADDR_UNSPECIFIED(const a: PInAddr6): boolean;
 begin


### PR DESCRIPTION
Under FPC use TLibHandle instead of THandle. THandle is 32bit under x64 FPC
Using THandle cause a very strange exception what depends on how many libraries are loaded by operation system yet. 