### PR TITLE
Note that sqlite3 var is freed in finalization section

### DIFF
--- a/SynSQLite3.pas
+++ b/SynSQLite3.pas
@@ -2295,6 +2295,9 @@ var
   // TSQLite3LibraryDynamic instance:
   // ! FreeAndNil(sqlite3); // release any previous instance
   // ! sqlite3 := TSQLite3LibraryDynamic.Create;
+  // - caller should free the sqlite3 instance only with
+  // ! FreeAndNil(sqlite3);
+  // to avoid issues with the automatic freeing in finalization section
   sqlite3: TSQLite3Library;
 
 


### PR DESCRIPTION
`sqlite3` variable is freed automatically in `finalization` section of the unit,
if you use `sqlite3.Free` in the cleanup part (e.g. executed on closing your application)
you might get an AV because the object is already freed by the finalization code.
If you only use `FreeAndNil` to free it, you'll be safe in all cases as it's independent of 
the ordering of unloading the units and therefore execution of `finalization` code.