### PR TITLE
Ensure that settings folder will be returned with trailing backslash

### DIFF
--- a/SQLite3/mORMotService.pas
+++ b/SQLite3/mORMotService.pas
@@ -1760,6 +1760,7 @@ begin
   fn := aSettingsFolder;
   if fn = '' then
     fn := {$ifdef MSWINDOWS}fWorkFolderName{$else}'/etc/'{$endif};
+  fn :=  EnsureDirectoryExists(fn);
   if aSettingsName = '' then
     fn := fn + UTF8ToString(ExeVersion.ProgramName)
   else


### PR DESCRIPTION
If aSettingsFolder is passed without trailing backslash at the end, the result of the file will be 
../myfolderSettingsFile.settings
Rather than
../myfolder/SettingsFile.settings