### PR TITLE
ajust logging of SynOleDB to be as in other TSQLDBStatement descendants

### DIFF
--- a/SynOleDB.pas
+++ b/SynOleDB.pas
@@ -2103,7 +2103,6 @@ end;
 destructor TOleDBStatement.Destroy;
 begin
   try
-    SynDBLog.Add.Log(sllDB,'Rows = %',[self,TotalRowsRetrieved],self);
     CloseRowSet;
   finally
     fCommand := nil;


### PR DESCRIPTION
This patch remove logging of SynOleDB statement inside destroy, since all other TSQLDBStatement descendants do not put itself into log on this point

This gives uniformity of logs and remove unexpected verbously for SynOleDB (compared to othed DB access layers)