### PR TITLE
Disable dynamic Conditionals for ZeosLib

### DIFF
--- a/Packages/README.md
+++ b/Packages/README.md
@@ -22,8 +22,9 @@ If you want to use *ZeosLib*, you must setup the package before compile it, foll
 2. Click on Options
 3. In "Compile Options", click on "Custom Options"
 4. Click on "Defines" and uncheck `NOSYNDBZEOS` conditional
-5. Save and return to Package
-6. Compile
+5. Add `zcomponent` package from *ZeosLib* into it.
+6. Save and return to Package
+7. Compile
 
 If you have compiled without using this option before, follow the steps above, but using "More > Recompile Clean" option to recompile the package.
 

--- a/Packages/mormot_base.lpk
+++ b/Packages/mormot_base.lpk
@@ -21,6 +21,7 @@ begin
   IncPath += ';$(ProjOutDir);$PkgDir(zcore)\..\..\src';
 end;"/>
       <Other>
+        <CustomOptions Value="-dNOSYNDBZEOS"/>
         <OtherDefines Count="1">
           <Define0 Value="NOSYNDBZEOS"/>
         </OtherDefines>

--- a/Packages/mormot_base.lpk
+++ b/Packages/mormot_base.lpk
@@ -9,17 +9,11 @@
       <Version Value="11"/>
       <PathDelim Value="\"/>
       <SearchPaths>
-        <IncludeFiles Value="..;..\SQLite3"/>
+        <IncludeFiles Value="$PkgDir(zcore)\..\..\src;..;..\SQLite3"/>
         <Libraries Value="..\static\$(TargetCPU)-$(TargetOS)"/>
         <OtherUnitFiles Value="..;..\SQLite3;..\SQLite3\DDD\infra"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
-      <Conditionals Value="// ZeosLib paths
-if undefined(NOSYNDBZEOS) then
-begin
-  UnitPath += ';$PkgOutDir(zcore);$PkgOutDir(zdbc);$PkgOutDir(zparsesql);$PkgOutDir(zplain)';
-  IncPath += ';$(ProjOutDir);$PkgDir(zcore)\..\..\src';
-end;"/>
       <Other>
         <CustomOptions Value="-dNOSYNDBZEOS"/>
         <OtherDefines Count="1">


### PR DESCRIPTION
Let's disable conditionals until next Lazarus version or "forever".
- see [comments](https://lists.lazarus-ide.org/pipermail/lazarus/2019-July/236729.html) and [patch](https://svn.freepascal.org/cgi-bin/viewvc.cgi/trunk/packager/interpkgconflictfiles.pas?root=lazarus&r1=61607&r2=61606&pathrev=61607) about it.