### PR TITLE
introduce TSynLog.ForceRotation method

### DIFF
--- a/SynLog.pas
+++ b/SynLog.pas
@@ -1075,6 +1075,8 @@ type
     procedure DisableRemoteLog(value: boolean);
     /// the associated TSynLog class
     function LogClass: TSynLogClass; {$ifdef HASINLINENOTX86}inline;{$endif}
+    /// Force log rotation; Can be used for example inside SUGHUP signal handler
+    procedure ForceRotation;
     /// direct access to the low-level writing content
     // - should usually not be used directly, unless you ensure it is safe
     property Writer: TTextWriter read fWriter;
@@ -4183,6 +4185,16 @@ begin
   if self=nil then
     result := nil else
     result := PPointer(self)^;
+end;
+
+procedure TSynLog.ForceRotation;
+begin
+  EnterCriticalSection(GlobalThreadLock);
+  try
+    PerformRotation;
+  finally
+    LeaveCriticalSection(GlobalThreadLock);
+  end;
 end;
 
 procedure TSynLog.DisableRemoteLog(value: boolean);


### PR DESCRIPTION
This method allow us to release a log file descriptor;
I'm use it in a SIGHUP signal handler. By Unix convention in response to SIGHUP signal daemon should reload configuration and reopen all opened files. 

As a side effect with a combination of custom OnRotate handler + ForceRotation we can use a Unix logrotate for complex log rotation scenarios