### PR TITLE
fix SynCurl build for FPC Win64

### DIFF
--- a/SynCurl.pas
+++ b/SynCurl.pas
@@ -573,7 +573,7 @@ begin
           {$endif Linux},[LIBCURL_DLL]);
       P := @@curl.global_init;
       for api := low(NAMES) to high(NAMES) do begin
-        P^ := GetProcAddress(curl.Module,{$ifndef FPC}PChar{$endif}('curl_'+NAMES[api]));
+        P^ := GetProcAddress(curl.Module,PChar('curl_'+NAMES[api]));
         if P^=nil then
           raise ECurl.CreateFmt('Unable to find %s() in %s',[NAMES[api],LIBCURL_DLL]);
         inc(P);


### PR DESCRIPTION
PChar is OK there for all compilers/platforms - the same used in SynDBOracle OCI_ENTRIES many years

with this ifdef I got compiler error under FPC for Win64 (for Lunux - not)