### PR TITLE
AccessViolation

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -58007,7 +58007,9 @@ function TInterfaceResolverForSingleInterface.GetImplementationName: string;
 begin
   if self=nil then
     result := '' else
-    result := string(fImplementation.ItemClass.ClassName);
+    if fImplementation.ItemClass=nil then
+      result := '' else
+      result := string(fImplementation.ItemClass.ClassName);
 end;
 
 function TInterfaceResolverForSingleInterface.GetOneInstance(out Obj): boolean;


### PR DESCRIPTION
Trying to resolve one not registered interface, framework try to raise an exception and serialize Self, fImplementation.ItemClass is nil.

Stacktrace:
System.TObject.ClassName
mORMot.TInterfaceResolverForSingleInterface.GetImplementationName
mORMot.SubProc(picMethod,($19DA78, $200000C))
mORMot.TPropInfo.GetUnicodeStrProp($2CC4B20,'')
mORMot.WriteProp($5C19B9)
mORMot.WritePropsFromRTTI(TClass($5C1780))
mORMot.TJSONSerializer.WriteObject($2CC4B20,[woHumanReadable,woDontStoreDefault,woStoreClassName,woStorePointer])
SynCommons.ObjectToJSON($2CC4B20,[woHumanReadable,woDontStoreDefault,woStoreClassName,woStorePointer])
mORMot.ObjectToJSONDebug($2CC4B20,[woHumanReadable,woDontStoreDefault,woStoreClassName,woStorePointer])
mORMotDDD.EDDDRepository.CreateUTF8($2CC4B20,'%.Create(%): Interface not registered - you could use TInterfaceFactory.RegisterInterfaces()',(...))
mORMotDDD.TDDDRepositoryRestFactory.Create((7880080, 49760, 705, (148, 254, 25, 0, 103, 137, 97, 0)),TDDDRepositoryRestClass($78389C),TClass($78329C),$2C1C260,TSQLRecordClass($667BE0),(...),nil)
mORMotDDD.TDDDRepositoryRestFactory.Create((7880080, 64360, 120, (32, 75, 204, 2, 232, 254, 25, 0)),TDDDRepositoryRestClass($78389C),TClass($78329C),$2C1C260,TSQLRecordClass($667BE0),nil)
Peti.backend.Dom.UserMobile.TInfraRepoUserMobileFactory.Create($2C1C260,nil)
Peti.backend.Dom.UserMobile.Peti.backend.Dom.UserMobile
System.InitUnits
System._StartExe(???,???)
SysInit._InitExe($788B90)
Peti.backend.Peti.backend
:77390419 KERNEL32.BaseThreadInitThunk + 0x19
:7770662d ntdll.RtlGetAppContainerNamedObjectPath + 0xed
:777065fd ntdll.RtlGetAppContainerNamedObjectPath + 0xbd