### PR TITLE
allow to modify socket backlog length

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -3227,6 +3227,15 @@ type
 function WinHTTP_WebSocketEnabled: boolean;
 {$endif}
 
+var
+  /// Queue length for completely established sockets waiting to be accepted,
+  // a backlog parameter for listen() function. If queue overflows client
+  // got ECONNREFUSED error for connect() call
+  // - for windows default is taken from SynWinSock ($7fffffff) and should
+  // not be modified. Actual limit is 200;
+  // - for Unix default is taken from SynFPCSock (128 as in linux cernel >2.2),
+  // but actual value is min(DefaultListenBacklog, /proc/sys/net/core/somaxconn)
+  DefaultListenBacklog: integer = SOMAXCONN;
 
 implementation
 
@@ -4596,7 +4605,7 @@ begin
     SetInt32Option(result,SO_LINGER,5);
     // bind and listen to this port
     if (Bind(result,sin)<>0) or
-       ((aLayer<>cslUDP) and (Listen(result,SOMAXCONN)<>0)) then begin
+       ((aLayer<>cslUDP) and (Listen(result,DefaultListenBacklog)<>0)) then begin
       CloseSocket(result);
       result := -1;
     end;

--- a/SynFPCSock.pas
+++ b/SynFPCSock.pas
@@ -194,7 +194,8 @@ const
 {$IFDEF BSD}
   SO_NOSIGPIPE  = $1022;
 {$ENDIF}
-  SOMAXCONN     = 1024;
+  // we use Linux default here
+  SOMAXCONN     = 128;
 
   IPV6_UNICAST_HOPS     = sockets.IPV6_UNICAST_HOPS;
   IPV6_MULTICAST_IF     = sockets.IPV6_MULTICAST_IF;


### PR DESCRIPTION
- new variable SynCrtSock.DefaultListenBacklog added and used as backlog parameter value for socket Listen()
-  unix backlog default (SynFPCSock.SOMAXCONN) is changed to 128 as in Linux kernel defaults (`cat /proc/sys/net/core/somaxconn`)

In case linux kernel is configured for high network performance (for some other services) by increasing somaxconn, previous default SynFPCSock.SOMAXCONN=1028 is too big . For example nginx/redis default is 511 on linux