### PR TITLE
Do not include input data if optNoLogInput or SPI parameters are present in an error message of failed requests.

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -62415,6 +62415,8 @@ begin
           error := GetErrorMessage(status);
           if error<>'' then
             error := ' - '+error;
+          if (optNoLogInput in fExecution[m].Options) or ([smdConst,smdVar]*service^.HasSPIParams<>[]) then
+            sent := '';
           aErrorMsg^ := FormatUTF8('URI % % returned status ''%'' (%%)',
             [uri,sent,resp,status,error]);
         end else


### PR DESCRIPTION
If included, sensitive data will be logged in the exception message.