### PR TITLE
SynDBOracle for x64: try to fix binding of BLOBs longer than 2000

### DIFF
--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -2917,7 +2917,7 @@ begin
               if Length(VData) > MaxInt then
                 raise ESQLDBOracle.CreateUTF8(
                   '%.ExecutePrepared: Maximum blob parameter length exceeded for parameter #%',[self,i+1]);
-              {$endof}
+              {$endif}
               oLength := Length(VData);
               if oLength<2000 then begin
                 VDBTYPE := SQLT_BIN;

--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -2913,6 +2913,14 @@ begin
                 oData := pointer(VData);
               end else begin
                 VDBTYPE := SQLT_LVB;
+                {$ifdef CPU64}
+                // Oracle expect SQLT_LVB layout as raw data prepended by int32 data length
+                // in case of CPU64 TSQLDBParam.VData is a String and length is stored as SizeInt = Int64 (not int32)
+                // I (mpv) dont like DIRTY hack below, but currently do not now how do did it better
+                // Line below copy string length to the HI bytes of TStrRec.length
+                PInteger(Pointer(PtrInt(VData)-sizeof(Integer)))^ := PInteger(Pointer(PtrInt(VData)-sizeof(PtrInt)))^;
+                // do we need to cleanup HI bytes of length or delphy/FPC ignores it?
+                {$endif}
                 oData := Pointer(PtrInt(VData)-sizeof(Integer));
                 Inc(oLength,sizeof(Integer));
               end;


### PR DESCRIPTION
Oracle expect SQLT_LVB layout as raw data prepended by int32 data length for both x32 and x64
In case of x64 TSQLDBParam.VData is a String and length is stored as SizeInt = Int64 (not int32)
I made a DIRTY hack - it works at last for Oracle POW, but I need @synopse attention. 

Mat be exists better solution, or if not - do we need to modify string length back after call to OCI.StmtExecute or Delphi/FPC ignores HI Bytes in length?