### PR TITLE
Allow CACertFile to be set separately than client cert info, also set…

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -2492,11 +2492,15 @@ type
     function InternalRetrieveAnswer(var Header,Encoding,AcceptEncoding, Data: SockString): integer; override;
     procedure InternalCloseRequest; override;
     procedure InternalAddHeader(const hdr: SockString); override;
+    function GetCACertFile:SockString;
+    procedure SetCACertFile(const aCertFile:SockString);
   public
     /// returns TRUE if the class is actually supported on this system
     class function IsAvailable: boolean; override;
     /// release the connection
     destructor Destroy; override;
+
+    property CACertFile:SockString read GetCACertFile write SetCACertFile;
     /// set the client SSL certification details
     // - used e.g. as
     // ! UseClientCertificate('testcert.pem','cacert.pem','testkey.pem','pass');
@@ -11506,6 +11510,17 @@ begin
   inherited;
 end;
 
+function TCurlHTTP.GetCACertFile:SockString;
+begin
+  Result := fSSL.CACertFile;
+end;
+
+procedure TCurlHTTP.SetCACertFile(const aCertFile:SockString);
+begin
+  fSSL.CACertFile := aCertFile;
+end;
+
+
 procedure TCurlHTTP.UseClientCertificate(
   const aCertFile, aCACertFile, aKeyName, aPassPhrase: SockString);
 begin
@@ -11542,6 +11557,9 @@ begin
         curl.easy_setopt(fHandle,coSSLKey,pointer(fSSL.KeyName));
         curl.easy_setopt(fHandle,coCAInfo,pointer(fSSL.CACertFile));
         curl.easy_setopt(fHandle,coSSLVerifyPeer,1);
+      end
+      else if fSSL.CACertFile <> '' then begin
+        curl.easy_setopt(fHandle,coCAInfo,pointer(fSSL.CACertFile));
       end;
     end;
   curl.easy_setopt(fHandle,coUserAgent,pointer(fExtendedOptions.UserAgent));


### PR DESCRIPTION
… CAInfo when no client cert is present

Fixes TLS on Windows without a client certificate