### PR TITLE
Update SynLog.pas to allow overriding LogCurrentTime

### DIFF
--- a/SynLog.pas
+++ b/SynLog.pas
@@ -861,7 +861,7 @@ type
     // any call to this method MUST call LogTrailerUnLock
     function LogHeaderLock(Level: TSynLogInfo; AlreadyLocked: boolean): boolean;
     procedure LogTrailerUnLock(Level: TSynLogInfo); {$ifdef HASINLINENOTX86}inline;{$endif}
-    procedure LogCurrentTime;
+    procedure LogCurrentTime; virtual;
     procedure LogFileInit; virtual;
     procedure LogFileHeader; virtual;
     {$ifndef DELPHI5OROLDER}


### PR DESCRIPTION
Made TSynLog.LogCurrentTime virtual, to allow customized handling in application classes.