### PR TITLE
AES CTR mode is broken

### DIFF
--- a/SynCrypto.pas
+++ b/SynCrypto.pas
@@ -13054,9 +13054,9 @@ begin
   inherited; // CV := IV + set fIn,fOut
   for i := 1 to Count shr 4 do begin
     TAESContext(AES.Context).DoBlock(AES.Context,fCV,tmp);
-    inc(fCV[7]); // counter is in the lower 64 bits, nonce in the upper 64 bits
-    if fCV[7]=0 then begin // manual big-endian increment
-      j := 6;
+    inc(fCV[15]); // counter is in the lower 64 bits, nonce in the upper 64 bits
+    if fCV[15]=0 then begin // manual big-endian increment
+      j := 14;
       repeat
         inc(fCV[j]);
         if (fCV[j]<>0) or (j=0) then


### PR DESCRIPTION
Hello.

The AES CTR mode is broken.

According to NIST SP 800-38A document, test vectors for AES128 CTR mode are:

> F.5.2 CTR-AES128.Decrypt
> Key 2b7e151628aed2a6abf7158809cf4f3c 
> 
> Init. Counter f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff 
> 
> Block #1 
> 
> Input Block f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff 
> 
> Output Block ec8cdf7398607cb0f2d21675ea9ea1e4 
> 
> Ciphertext 874d6191b620e3261bef6864990db6ce 
> 
> Plaintext 6bc1bee22e409f96e93d7e117393172a 
> 
> Block #2 
> 
> Input Block f0f1f2f3f4f5f6f7f8f9fafbfcfdff00 
> 
> Output Block 362b7c3c6773516318a077d7fc5073ae 
> 
> Ciphertext 9806f66b7970fdff8617187bb9fffdff 
> 
> Plaintext ae2d8a571e03ac9c9eb76fac45af8e51 
> 
> Block #3 
> 
> Input Block f0f1f2f3f4f5f6f7f8f9fafbfcfdff01 
> 
> Output Block 6a2cc3787889374fbeb4c81b17ba6c44 
> 
> Ciphertext 5ae4df3edbd5d35e5b4f09020db03eab 
> 
> Plaintext 30c81c46a35ce411e5fbc1191a0a52ef 
> 
> Block #4 
> 
> Input Block f0f1f2f3f4f5f6f7f8f9fafbfcfdff02 
> 
> Output Block e89c399ff0f198c6d40a31db156cabfe 
> 
> Ciphertext 1e031dda2fbe03d1792170a0f3009cee 
> 
> Plaintext f69f2445df4f9b17ad2b417be66c3710 

So decrypting a ciphertext: **874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff5ae4df3edbd5d35e5b4f09020db03eab1e031dda2fbe03d1792170a0f3009cee**

Should yield to **6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710** plaintext.

With current SynCrypto.pas following plaintext is generated:

**6bc1bee22e409f96e93d7e117393172a_2fd49f200e06fee142bb33586f61a3b7e0f54cbac8d2368ed0004e8786feebb2dfc95079569c95d480537e2279ab9e4c_**

The corruption yields after first AES block, and this is because wrong increasing offset in syncrypto.

Following can be verified by code snippet:

> var
>   A: TAesCtr;
>   AES_IV: TAESBLOCK;
>   Key,Iv,buf,buf2: array of byte;
> begin
> PFU_HexToDynBuffer('2b7e151628aed2a6abf7158809cf4f3c', @Key);
> PFU_HexToDynBuffer('f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff', @Iv);
> PFU_HexToDynBuffer('874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff5ae4df3edbd5d35e5b4f09020db03eab1e031dda2fbe03d1792170a0f3009cee', @buf);
> A := TAesCtr.Create(key[0], length(key)*8);
> Move(IV[0], AES_IV[0], length(AES_IV));
> A.IV:=AES_IV;
> A.Decrypt(@buf[0], @buf[0], Length(Buf));
> Memo1.Lines.Add(LowerCase(PFU_DynBufferToHex(buf)));   

Perhaps I haven't missed anything in Initialization code or Endianess settings? Rather no - data is referenced byte-wise rather than dword-wise.