### PR TITLE
SynDBOracle: fix logn term x64 AV

### DIFF
--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -537,7 +537,7 @@ type
   dvoid   = Pointer;
   text    = PAnsiChar;
   OraText = PAnsiChar;
-  size_T  = Integer;
+  size_T  = PtrUInt;
 
   pub1 = ^ub1;
   psb1 = ^sb1;


### PR DESCRIPTION
I cried. I have been looking for a mistake for so long