### PR TITLE
fixed W1035 Warnings in TOpenSSL* stubs

### DIFF
--- a/SynOpenSSL.pas
+++ b/SynOpenSSL.pas
@@ -813,7 +813,7 @@ end;
 function TOpenSSLConnectionClient.Connect(const Read, Write: TOnOpenSSLData;
   Level: TOpenSSLConnectionLevel; Options: TOpenSSLConnectionOptions): boolean;
 begin
-
+  result := false;
 end;
 
 procedure TOpenSSLConnectionClient.Disconnect;
@@ -828,7 +828,7 @@ end;
 
 function TOpenSSLConnectionClient.SecureWrite(Buffer: pointer; Len: integer): boolean;
 begin
-
+  result := false;
 end;
 
 procedure TOpenSSLConnectionClient.SetNotify(States: TOpenSSLConnectionStates;


### PR DESCRIPTION
- [dcc64 Warning] SynOpenSSL.pas(817): W1035 Return value of function 'TOpenSSLConnectionClient.Connect' might be undefined
- [dcc64 Warning] SynOpenSSL.pas(832): W1035 Return value of function 'TOpenSSLConnectionClient.SecureWrite' might be undefined