### PR TITLE
dddInfra: Add lengths for RawUTF8 fields

### DIFF
--- a/SQLite3/DDD/infra/dddInfraAuthRest.pas
+++ b/SQLite3/DDD/infra/dddInfraAuthRest.pas
@@ -77,11 +77,11 @@ type
   published
     /// will map TAuthInfo.LogonName
     // - is defined as "stored AS_UNIQUE" so that it may be used as primary key
-    property Logon: RawUTF8 read fLogon write fLogon stored AS_UNIQUE;
+    property Logon: RawUTF8 index 128 read fLogon write fLogon stored AS_UNIQUE;
     /// the password, stored in a hashed form
     // - this property does not exist at TAuthInfo level, so will be private
     // to the storage layer - which is the safest option possible
-    property HashedPassword: RawUTF8 read fHashedPassword write fHashedPassword;
+    property HashedPassword: RawUTF8 index 128 read fHashedPassword write fHashedPassword;
   end;
 
   /// generic class for implementing authentication

--- a/SQLite3/DDD/infra/dddInfraEmail.pas
+++ b/SQLite3/DDD/infra/dddInfraEmail.pas
@@ -200,7 +200,7 @@ type
     fEmail: RawUTF8;
   published
     /// the stored email address
-    property Email: RawUTF8 read fEmail write fEmail;
+    property Email: RawUTF8 index 128 read fEmail write fEmail;
   end;
 
   /// ORM class for email validation process
@@ -217,11 +217,11 @@ type
   public
     function IsValidated(const aEmail: RawUTF8): Boolean;
   published
-    property Logon: RawUTF8 read fLogon write fLogon stored AS_UNIQUE;
+    property Logon: RawUTF8 index 128 read fLogon write fLogon stored AS_UNIQUE;
     property RequestTime: TTimeLog read fRequestTime write fRequestTime;
     property ValidationSalt: Integer read fValidationSalt write fValidationSalt;
     property ValidationTime: TTimeLog read fValidationTime write fValidationTime;
-    property ValidationIP: RawUTF8 read fValidationIP write fValidationIP;
+    property ValidationIP: RawUTF8 index 128 read fValidationIP write fValidationIP;
   end;
 
 


### PR DESCRIPTION
Added lengths for RawUTF8 fields in TSQLRecordEmailAbstract, TSQLRecordEmailValidation and TSQLRecordUserAuth.
Latest MariaDB has issues when the lengths are left unspecified and attempt is made to create them using MEDIUMTEXT.