### PR TITLE
allow to decompress zero length zstream

### DIFF
--- a/SynZip.pas
+++ b/SynZip.pas
@@ -1613,7 +1613,7 @@ end;
 function TGZRead.ToMem: ZipString;
 begin
   result := '';
-  if comp=nil then
+  if (comp=nil) or ((uncomplen32=0) and (crc32=0){0 length stream}) then
     exit;
   SetLength(result,uncomplen32);
   if (UnCompressMem(comp,pointer(result),complen,uncomplen32)<>integer(uncomplen32)) or


### PR DESCRIPTION
I got an issue while sends request to 3-paty service (web server is Apache, app is Cisco web service, so I think this is really Apache behavior):
I send a PUT request with what should returns 200 OK with empty body and `Transfer-Encoding: chunked` (no Content-Length header)
In case I adds `Accept-Encoding: gzip;` header service returns empty gzip in body. The response content is 
```
(master)$ xxd r.bin 
00000000: 1f8b 0800 0000 0000 0003 0000 00ff ff03  ................
00000010: 0000 0000 0000 0000 00                   .........
```
SynZip fails on such ZIP package. This patch fix it