### PR TITLE
Featurte/silence db log

### DIFF
--- a/SynDB.pas
+++ b/SynDB.pas
@@ -7547,7 +7547,7 @@ end;
 procedure TSQLDBStatement.Reset;
 begin
   fSQLWithInlinedParams := '';
-  // a do-nothing default method (used e.g. for OCI)
+  fSQLLogTimer.Init; // reset timer (for cached statement for example)
 end;
 
 procedure TSQLDBStatement.ReleaseRows;

--- a/SynDBODBC.pas
+++ b/SynDBODBC.pas
@@ -1261,7 +1261,9 @@ begin
 end;
 
 procedure TODBCConnection.StartTransaction;
+var log: ISynLog;
 begin
+  log := SynDBLog.Enter(self,'StartTransaction');
   if TransactionCount>0 then
     raise EODBCException.CreateUTF8('% do not support nested transactions',[self]);
   inherited StartTransaction;

--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -2426,8 +2426,10 @@ begin
   try
     fTimeElapsed.Resume;
     FreeHandles(false);
+    {$ifndef SYNDB_SILENCE}
     SynDBLog.Add.Log(sllDB,'Destroy: stats = % row(s) in %',
       [TotalRowsRetrieved,fTimeElapsed.Stop],self);
+    {$endif}
   finally
     inherited;
   end;
@@ -3269,11 +3271,9 @@ end;
 
 procedure TSQLDBOracleStatement.Prepare(const aSQL: RawUTF8;
   ExpectResults: Boolean);
-var oSQL: RawUTF8;
-    env: POCIEnv;
-    cached: boolean;
+var env: POCIEnv;
+    L: PtrInt;
 begin
-  cached := false;
   SQLLogBegin(sllDB);
   try
     try
@@ -3281,21 +3281,28 @@ begin
         raise ESQLDBOracle.CreateUTF8('%.Prepare should be called only once',[self]);
       // 1. process SQL
       inherited Prepare(aSQL,ExpectResults); // set fSQL + Connect if necessary
-      fPreparedParamsCount := ReplaceParamsByNames(aSQL,oSQL);
+      fPreparedParamsCount := ReplaceParamsByNumbers(aSQL,fSQLPrepared,':');
+      L := Length(fSQLPrepared);
+      while (L>0) and (fSQLPrepared[L] in [#1..' ',';']) do
+      if (fSQLPrepared[L]=';') and (L>5) and IdemPChar(@fSQLPrepared[L-3],'END') then
+        break else // allows 'END;' at the end of a statement
+        dec(L);    // trim ' ' or ';' right (last ';' could be found incorrect)
+      if L <> Length(fSQLPrepared) then
+        fSQLPrepared := copy(aSQL,1,L); // trim right ';' if any
       // 2. prepare statement
       env := (Connection as TSQLDBOracleConnection).fEnv;
       with OCI do begin
         HandleAlloc(env,fError,OCI_HTYPE_ERROR);
         if fUseServerSideStatementCache then begin
           if StmtPrepare2(TSQLDBOracleConnection(Connection).fContext,fStatement,
-             fError,pointer(oSQL),length(oSQL),nil,0,OCI_NTV_SYNTAX,
+             fError,pointer(fSQLPrepared),length(fSQLPrepared),nil,0,OCI_NTV_SYNTAX,
              OCI_PREP2_CACHE_SEARCHONLY) = OCI_SUCCESS then
-            cached := true else
+            fCacheIndex := 1 else
           Check(nil,self,StmtPrepare2(TSQLDBOracleConnection(Connection).fContext,fStatement,
-            fError,pointer(oSQL),length(oSQL),nil,0,OCI_NTV_SYNTAX,OCI_DEFAULT),fError);
+            fError,pointer(fSQLPrepared),length(fSQLPrepared),nil,0,OCI_NTV_SYNTAX,OCI_DEFAULT),fError);
         end else begin
           HandleAlloc(env,fStatement,OCI_HTYPE_STMT);
-          Check(nil,self,StmtPrepare(fStatement,fError,pointer(oSQL),length(oSQL),
+          Check(nil,self,StmtPrepare(fStatement,fError,pointer(fSQLPrepared),length(fSQLPrepared),
             OCI_NTV_SYNTAX,OCI_DEFAULT),fError);
         end;
       end;
@@ -3308,7 +3315,7 @@ begin
       end;
     end;
   finally
-    fTimeElapsed.FromExternalMicroSeconds(SQLLogEnd(' cache=%',[cached]));
+    fTimeElapsed.FromExternalMicroSeconds(SQLLogEnd(' cache=%',[fCacheIndex]));
   end;
 end;
 

--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -3281,14 +3281,14 @@ begin
         raise ESQLDBOracle.CreateUTF8('%.Prepare should be called only once',[self]);
       // 1. process SQL
       inherited Prepare(aSQL,ExpectResults); // set fSQL + Connect if necessary
-      fPreparedParamsCount := ReplaceParamsByNumbers(aSQL,fSQLPrepared,':');
+      fPreparedParamsCount := ReplaceParamsByNumbers(aSQL,fSQLPrepared,':', true);
       L := Length(fSQLPrepared);
       while (L>0) and (fSQLPrepared[L] in [#1..' ',';']) do
       if (fSQLPrepared[L]=';') and (L>5) and IdemPChar(@fSQLPrepared[L-3],'END') then
         break else // allows 'END;' at the end of a statement
         dec(L);    // trim ' ' or ';' right (last ';' could be found incorrect)
       if L <> Length(fSQLPrepared) then
-        fSQLPrepared := copy(aSQL,1,L); // trim right ';' if any
+        fSQLPrepared := copy(fSQLPrepared,1,L); // trim right ';' if any
       // 2. prepare statement
       env := (Connection as TSQLDBOracleConnection).fEnv;
       with OCI do begin

--- a/SynDBPostgres.pas
+++ b/SynDBPostgres.pas
@@ -89,7 +89,8 @@ type
     // the associated low-level provider connection
     fPGConn: pointer;
     // fServerSettings: set of (ssByteAasHex);
-    // maintain fPrepared[] hash list to identify already cached
+    // maintain fPrepared[] hash list to identify already cached;
+    // return statement position in prepared cache
     function PrepareCached(const aSQL: RawUTF8; aParamCount: integer;
       out aName: RawUTF8): integer;
     /// direct execution of SQL statement what do not returns a result
@@ -131,7 +132,6 @@ type
   TSQLDBPostgresStatement = class(TSQLDBStatementWithParamsAndColumns)
   protected
     fPreparedStmtName: RawUTF8; // = SHA-256 of the SQL
-    fParsedSQL: RawUTF8;
     fPreparedParamsCount: integer;
     fRes: pointer;
     fResStatus: integer;
@@ -755,20 +755,18 @@ end;
 // see https://www.postgresql.org/docs/9.3/libpq-exec.html
 
 procedure TSQLDBPostgresStatement.Prepare(const aSQL: RawUTF8; ExpectResults: boolean);
-var
-  fromcache: integer;
 begin
   SQLLogBegin(sllDB);
   if aSQL = '' then
     raise ESQLDBPostgres.CreateUTF8('%.Prepare: empty statement', [self]);
   inherited Prepare(aSQL, ExpectResults); // will strip last ;
-  fPreparedParamsCount := ReplaceParamsByNumbers(fSQL, fParsedSQL, '$');
-  if (fPreparedParamsCount > 0) and (IdemPCharArray(pointer(fParsedSQL),
+  fPreparedParamsCount := ReplaceParamsByNumbers(fSQL, fSQLPrepared, '$');
+  if (fPreparedParamsCount > 0) and (IdemPCharArray(pointer(fSQLPrepared),
       ['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'VALUES']) >= 0) then
   begin // preparable
-    fromcache := TSQLDBPostgresConnection(fConnection).PrepareCached(
-      fParsedSQL, fPreparedParamsCount, fPreparedStmtName);
-    SQLLogEnd(' name=% cache=%', [fPreparedStmtName, fromcache]);
+    fCacheIndex := TSQLDBPostgresConnection(fConnection).PrepareCached(
+      fSQLPrepared, fPreparedParamsCount, fPreparedStmtName);
+    SQLLogEnd(' name=% cache=%', [fPreparedStmtName, fCacheIndex]);
   end
   else
     SQLLogEnd;
@@ -784,7 +782,7 @@ var
   c: TSQLDBPostgresConnection;
 begin
   SQLLogBegin(sllSQL);
-  if fParsedSQL = '' then
+  if fSQLPrepared = '' then
     raise ESQLDBPostgres.CreateUTF8('%.ExecutePrepared: Statement not prepared', [self]);
   if fParamCount <> fPreparedParamsCount then
     raise ESQLDBPostgres.CreateUTF8('%.ExecutePrepared: Query expects % parameters ' +
@@ -839,9 +837,9 @@ begin
       pointer(fPGParams), pointer(fPGparamLengths), pointer(fPGParamFormats), PGFMT_TEXT)
   else if fPreparedParamsCount = 0 then
     // PQexec handles multiple SQL commands
-    fRes := PQ.Exec(c.fPGConn, pointer(fParsedSQL))
+    fRes := PQ.Exec(c.fPGConn, pointer(fSQLPrepared))
   else
-    fRes := PQ.ExecParams(c.fPGConn, pointer(fParsedSQL), fPreparedParamsCount, nil,
+    fRes := PQ.ExecParams(c.fPGConn, pointer(fSQLPrepared), fPreparedParamsCount, nil,
       pointer(fPGParams), pointer(fPGparamLengths), pointer(fPGParamFormats), PGFMT_TEXT);
   PQ.Check(c.fPGConn, fRes, @fRes, {forceClean=}false);
   fResStatus := PQ.ResultStatus(fRes);

--- a/SynDBZeos.pas
+++ b/SynDBZeos.pas
@@ -880,7 +880,9 @@ begin
 end;
 
 procedure TSQLDBZEOSConnection.StartTransaction;
+var log: ISynLog;
 begin
+  log := SynDBLog.Enter(self,'StartTransaction');
   inherited StartTransaction;
   {$IFDEF ZEOS73UP}
   fDatabase.StartTransaction; //returns the txn level


### PR DESCRIPTION
This pull request give developer an option to made a custom SQL execution log on the application layer by expose all necessary properties on ISQLDBStatement layer and mute a build-in SynDB* layer SQL execution logging; 
As a side effect:
 - missing StartTransaction logging added into SynDBODBC & SynDBZeos;
 - TSQLDBOracleStatement will use ReplaceParamsByNumbers (:1 :2 works well for Oracle)  instead of ReplaceParamsByNames (up to x10 times faster depending on parameters count);
 - SQLPrepared property moved into TSQLDBStatement, so SQL can be logged as it passed to DB ( with parameters as it in query replaced to $1 or :1 depends on database, semicolon stripped etc.). The reason for this is what execution plan for statement with parameter almost always is not equal to SQLStatementWithInlineParameters;
 - SQLLogTimer is moved into TSQLDBStatement. Can be used it to track query preparation/execution/fetch time on the application layer (for example to log slow queries into separate log level). Before this changes we start one more timer in our code;
 - CacheIndex  is moved into TSQLDBStatement. Can be used to track statements what hit a prepared statement cache and gather some statistics about it on the application layer;

We have a couple of hi-load production (~100Mb logs per minute) and need to: 
 - analyze a logs using script (grep, logstash). For example I want to grep all select statements across 200 files 200Mb each, group it by SQL statement and sort by occurrence with avg duration. 
 - minimize a log output (SynDB exception it too verbose because includes statement)
 - log a rows affected, total time(us), time to first row(us), cache hit/miss together with a statement

With help of this patch I can made my logging looks like (4 lines less for every SQL, can be analyzed using RegExp/grep, exception contains only important info):
(r=rows affected  t=total time(us)  fr=time to first row(us)  c=cache q=SQL)
```
20200505 18590825  " info  	Long fetch query (t <> tf) 
20200505 18590825  "  +    	DataStore.init(uba_user)
20200505 18590825  "  +    		App.fetchAllOrExec(conn=main/Oracle11)
20200505 18590826  " debug 			P1: Int64	1
20200505 18590850  " SQL   			r=3477 t=389472 fr=284732 c=-1 q=select ID, entity, actionType, actionUser, actionUserName, actionTime from uba_auditTrail where 1=:1
20200505 18590850  " cust2 			Slow query: t=389472. See statement above
20200505 18590850  "  -    		00.389.795
20200505 18590850  "  -    	00.393.279
20200505 18590850  " info  	Log updated count 
20200505 18590850  "  +    	App.fetchAllOrExec(conn=main/Oracle11)
20200505 18590850  " debug 		P1: Int64	1
20200505 18590850  "  +    		StartTransaction
20200505 18590850  "  -    		00.004.677
20200505 18590851  " SQL   		r=6 t=5290 c=-1 q=update uba_user set disabled = 0 where 1=:1
20200505 18590851  "  -    	00.010.190
20200505 18590851  " info  	Preparation error 
20200505 18590851  "  +    	DataStore.init(uba_user)
20200505 18590851  "  +    		App.fetchAllOrExec(conn=main/Oracle11)
20200505 18590852  " EXC   			ESQLDBOracle {"ESQLDBOracle":"TSQLDBOracleStatement error: ORA-00904: "UNKNOWN": invalid identifier"}{"ESQLDBOracle(7f8045473590)":[]} [] at   $000000000075DB08  $000000000076520F  $0000000000766954  $000000000073F35A  $000000000073F207  $00000000005CF7BC  $00000000005D0A7C  $00000000005D9E05  $000000000061AA89  $00007F804FA8BD78
20200505 18590852  " ERROR 			q=select UNKNOWN from uba_user where name = ?
20200505 18590852  "  -    		00.011.917
20200505 18590852  "  -    	00.011.997
```

Before patch
```
20200505 19073235  # info  	Long fetch query (t <> tf) 
20200505 19073235  #  +    	DataStore.init(uba_user)
20200505 19073235  #  +    		App.fetchAllOrExec
20200505 19073235  #  +    			App.prepareAndRun(conn=main/Oracle11)
20200505 19073235  # debug 				Statement cache miss
20200505 19073236  # debug 				P1: Int64	1
20200505 19073236  # SQL   				select ID, entity, actionType, actionUser, actionUserName, actionTime from uba_auditTrail where 1=?
20200505 19073257  #  -    			00.361.875
20200505 19073320  # cust2 			Slow query: 761.36ms. See above
20200505 19073320  # DB    			3477 row(s) in 752.13ms
20200505 19073320  #  -    		00.761.489
20200505 19073320  #  -    	00.765.603
20200505 19073320  # info  	Log updated count 
20200505 19073320  #  +    	App.fetchAllOrExec
20200505 19073320  #  +    		App.prepareAndRun(conn=main/Oracle11)
20200505 19073320  # debug 			Statement cache miss
20200505 19073320  # debug 			P1: Int64	1
20200505 19073320  #  +    			StartTransaction
20200505 19073321  #  -    			00.006.788
20200505 19073321  # DB    			StartT
20200505 19073235  # info  	Long fetch query (t <> tf) 
20200505 19073235  #  +    	DataStore.init(uba_user)
20200505 19073235  #  +    		App.fetchAllOrExec
20200505 19073235  #  +    			App.prepareAndRun(conn=main/Oracle11)
20200505 19073235  # debug 				Statement cache miss
20200505 19073236  # debug 				P1: Int64	1
20200505 19073236  # SQL   				select ID, entity, actionType, actionUser, actionUserName, actionTime from uba_auditTrail where 1=?
20200505 19073257  #  -    			00.361.875
20200505 19073320  # cust2 			Slow query: 761.36ms. See above
20200505 19073320  # DB    			3477 row(s) in 752.13ms
20200505 19073320  #  -    		00.761.489
20200505 19073320  #  -    	00.765.603
20200505 19073320  # info  	Log updated count 
20200505 19073320  #  +    	App.fetchAllOrExec
20200505 19073320  #  +    		App.prepareAndRun(conn=main/Oracle11)
20200505 19073320  # debug 			Statement cache miss
20200505 19073320  # debug 			P1: Int64	1
20200505 19073320  #  +    			StartTransaction
20200505 19073321  #  -    			00.006.788
20200505 19073321  # DB    			StartTransaction (conn=main)
20200505 19073321  # SQL   			update uba_user set disabled = 0 where 1=?
20200505 19073321  #  -    		00.018.767
20200505 19073321  # DB    		0 row(s) in 11.84ms
20200505 19073321  #  -    	00.018.929
20200505 19073321  # info  	Preparation error 
20200505 19073321  #  +    	DataStore.init(uba_user)
20200505 19073321  #  +    		App.fetchAllOrExec
20200505 19073321  #  +    			App.prepareAndRun(conn=main/Oracle11)
20200505 19073321  # debug 				Statement cache miss
20200505 19073322  # EXC   				ESQLDBOracle {"Statement":{"SQL":"select UNKNOWN from uba_user where name = ?","SQLWithInlinedParams":"select UNKNOWN from uba_user where name = ?","CurrentRow":0,"TotalRowsRetrieved":0,"Connection":{"Connected":true,"ServerTimestampAtConnection":"2020-05-05T22:07:32","TotalConnectionCount":1,"TransactionCount":1,"InTransaction":true,"RollbackOnDisconnect":true,"LastErrorMessage":"","LastErrorWasAboutConnection":false,"Properties":{"ClientVersion":"libclntsh.so rev. 19.6.0.0","EnvironmentInitializationMode":135,"InternalBufferSize":131072,"RowsPrefetchSize":131072,"BlobPrefetchSize":4096,"StatementCacheSize":30,"UseWallet":false,"IgnoreORA01453OnStartTransaction":true,"Engine":"ubSQLDBOracle","ServerName":"(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = ora12.unitybase.info)(PORT = 15211)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = oraub.cloud.local)))","DatabaseNameSafe":"","UserID":"UB5_AUTOTEST_LIN","DBMS":"Oracle","DBMSEngineName":"Oracle","BatchSendingAbilities":["Create","Update","Delete"],"BatchMaxSentAtOnce":10000,"LoggedSQLMaxSize":-1,"LogSQLStatementOnException":false,"ForcedSchemaName":"","UseCache":true,"RollbackOnDisconnect":true,"StoreVoidStringAsNull":false,"VariantStringAsWideString":false}},"StripSemicolon":true},"Message":"TSQLDBOracleStatement error: ORA-00904: \"UNKNOWN\": invalid identifier"} [] at 747c66 74f62f 750b85 74a215 5c481e 5c5b01 5cf68d 60d86f 7fc1a0e90d08
20200505 19073322  # ERROR 				"ESQLDBOracle(7fc199380180)":{"ESQLDBOracle(7fc199380180)":{"Statement":{"TSQLDBOracleStatement(7fc19968e460)":{"SQL":"select UNKNOWN from uba_user where name = ?","SQLWithInlinedParams":"select UNKNOWN from uba_user where name = ?","CurrentRow":0,"TotalRowsRetrieved":0,"Connection":{"TubSQLDBOracleConnection(7fc1988b7180)":{"Connected":true,"ServerTimestampAtConnection":"2020-05-05T22:07:32","TotalConnectionCount":1,"TransactionCount":1,"InTransaction":true,"RollbackOnDisconnect":true,"LastErrorMessage":"","LastErrorWasAboutConnection":false,"Properties":{"TubSQLDBOracleConnectionProperties(023252a0)":{"ClientVersion":"libclntsh.so rev. 19.6.0.0","EnvironmentInitializationMode":135,"InternalBufferSize":131072,"RowsPrefetchSize":131072,"BlobPrefetchSize":4096,"StatementCacheSize":30,"UseWallet":false,"IgnoreORA01453OnStartTransaction":true,"Engine":"ubSQLDBOracle","ServerName":"(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = ora12.unitybase.info)(PORT = 15211)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = oraub.cloud.local)))","DatabaseNameSafe":"","UserID":"UB5_AUTOTEST_LIN","DBMS":"Oracle","DBMSEngineName":"Oracle","BatchSendingAbilities":["Create","Update","Delete"],"BatchMaxSentAtOnce":10000,"LoggedSQLMaxSize":-1,"LogSQLStatementOnException":false,"ForcedSchemaName":"","UseCache":true,"RollbackOnDisconnect":true,"StoreVoidStringAsNull":false,"VariantStringAsWideString":false}}}},"StripSemicolon":true}},"Message":"TSQLDBOracleStatement error: ORA-00904: \"UNKNOWN\": invalid identifier"}}
20200505 19073322  # SQL   				select UNKNOWN from uba_user where name = ?
20200505 19073322  # DB    				0 row(s) in 11.50ms
20200505 19073322  # EXC   				EMetabaseException {"errorCode":0,"Message":"Internal server error"} [] at 5c4889 5c5b01 5cf68d 60d86f 7fc1a0e90d08
20200505 19073322  #  -    			00.011.705
20200505 19073322  #  -    		00.011.760
20200505 19073322  #  -    	00.011.814ransaction (conn=main)
20200505 19073321  # SQL   			update uba_user set disabled = 0 where 1=?
20200505 19073321  #  -    		00.018.767
20200505 19073321  # DB    		0 row(s) in 11.84ms
20200505 19073321  #  -    	00.018.929
```