### PR TITLE
ODBC SQL server 0.01

### DIFF
--- a/SynDBODBC.pas
+++ b/SynDBODBC.pas
@@ -1702,6 +1702,14 @@ begin
             end;
           ftDouble: begin
             CValueType := SQL_C_DOUBLE;
+            if (fDBMS = dMSSQL) and (VInOut=paramIn) then begin
+              // MPV: prevent "Invalid character value for cast specification" error for small digits like 0.01, -0.0001
+              // verified under Linux for msodbcsql17
+              // FreeTDS throws cast error with this fix (and without also)
+              ParameterType := SQL_NUMERIC;
+              ColumnSize := 9;
+              DecimalDigits := 6;
+            end;
             ParameterValue := pointer(@VInt64);
           end;
           ftCurrency:


### PR DESCRIPTION
 prevent "Invalid character value for cast specification" SQL Server error for small digits like 0.01, -0.0001