### PR TITLE
Feature/systemd master

### DIFF
--- a/SQLite3/Samples/11 - Exception logging/LogViewMain.lfm
+++ b/SQLite3/Samples/11 - Exception logging/LogViewMain.lfm
@@ -14,7 +14,7 @@ object MainLogView: TMainLogView
   OnCreate = FormCreate
   OnKeyDown = FormKeyDown
   OnShow = FormShow
-  LCLVersion = '1.7'
+  LCLVersion = '2.0.7.0'
   object Splitter2: TSplitter
     Cursor = crVSplit
     Left = 0
@@ -146,17 +146,17 @@ object MainLogView: TMainLogView
     end
     object lblServerRoot: TLabel
       Left = 16
-      Height = 13
+      Height = 14
       Top = 48
-      Width = 62
+      Width = 72
       Caption = 'Server Root:'
       ParentColor = False
     end
     object lblServerPort: TLabel
       Left = 16
-      Height = 13
+      Height = 14
       Top = 90
-      Width = 59
+      Width = 69
       Caption = 'Server Port:'
       ParentColor = False
     end
@@ -182,10 +182,11 @@ object MainLogView: TMainLogView
       PopupMenu = FilterMenu
       Style = lbOwnerDrawFixed
       TabOrder = 3
+      TopIndex = -1
     end
     object EditSearch: TEdit
       Left = 16
-      Height = 21
+      Height = 31
       Hint = 'Search (Ctrl+F, F3 for next) '
       Top = 40
       Width = 85
@@ -231,9 +232,9 @@ object MainLogView: TMainLogView
     end
     object MergedProfile: TCheckBox
       Left = 22
-      Height = 19
+      Height = 23
       Top = 283
-      Width = 112
+      Width = 137
       Caption = 'Merge method calls'
       OnClick = MergedProfileClick
       TabOrder = 5
@@ -261,8 +262,8 @@ object MainLogView: TMainLogView
       Top = 336
       Width = 118
       Caption = ' Threads '
-      ClientHeight = 78
-      ClientWidth = 114
+      ClientHeight = 81
+      ClientWidth = 116
       TabOrder = 8
       object BtnThreadNext: TButton
         Left = 8
@@ -374,7 +375,7 @@ object MainLogView: TMainLogView
     end
     object edtServerRoot: TEdit
       Left = 16
-      Height = 21
+      Height = 31
       Top = 64
       Width = 121
       TabOrder = 11
@@ -382,7 +383,7 @@ object MainLogView: TMainLogView
     end
     object edtServerPort: TEdit
       Left = 16
-      Height = 21
+      Height = 31
       Top = 106
       Width = 121
       TabOrder = 12
@@ -415,7 +416,9 @@ object MainLogView: TMainLogView
       Width = 121
       ItemHeight = 0
       OnDblClick = lstDaysDblClick
+      ScrollWidth = 119
       TabOrder = 15
+      TopIndex = -1
     end
   end
   object MemoBottom: TMemo
@@ -494,6 +497,7 @@ object MainLogView: TMainLogView
       OnClickCheck = ThreadListBoxClickCheck
       OnDblClick = ThreadListBoxDblClick
       TabOrder = 0
+      TopIndex = -1
     end
     object pnlThreadBottom: TPanel
       Left = 1
@@ -555,19 +559,19 @@ object MainLogView: TMainLogView
     end
   end
   object FilterMenu: TPopupMenu
-    left = 88
-    top = 16
+    Left = 88
+    Top = 16
   end
   object OpenDialog: TOpenDialog
     DefaultExt = '.log'
     Filter = 'Log|*.log;*.txt;*.synlz'
     Options = [ofHideReadOnly, ofPathMustExist, ofFileMustExist, ofEnableSizing]
-    left = 40
-    top = 80
+    Left = 40
+    Top = 80
   end
   object ListMenu: TPopupMenu
-    left = 40
-    top = 16
+    Left = 40
+    Top = 16
     object ListMenuCopy: TMenuItem
       Caption = '&Copy'
       OnClick = ListMenuCopyClick
@@ -577,14 +581,14 @@ object MainLogView: TMainLogView
     Enabled = False
     Interval = 200
     OnTimer = tmrRefreshTimer
-    left = 88
-    top = 80
+    Left = 88
+    Top = 80
   end
   object dlgSaveList: TSaveDialog
     DefaultExt = '.log'
     Filter = 'log|*.log|txt|*.txt|synlz|*.synlz'
     Options = [ofOverwritePrompt, ofHideReadOnly, ofEnableSizing]
-    left = 136
-    top = 16
+    Left = 136
+    Top = 16
   end
 end

--- a/SQLite3/Samples/11 - Exception logging/LogViewMain.pas
+++ b/SQLite3/Samples/11 - Exception logging/LogViewMain.pas
@@ -34,7 +34,9 @@ uses
   {$endif}
   SynCommons,
   SynLog,
+  {$ifdef WINDOWS}
   SynMemoEx,
+  {$endif}
   mORMotHttpServer;
 
 type
@@ -96,6 +98,9 @@ type
     btnThreadDown: TButton;
     btnThreadUp: TButton;
     lstDays: TListBox;
+    {$ifdef LINUX}
+    MemoBottom: TMemo;
+    {$endif}
     procedure FormCreate(Sender: TObject);
     procedure FormShow(Sender: TObject);
     procedure BtnFilterClick(Sender: TObject);
@@ -155,7 +160,9 @@ type
     procedure ThreadListNameRefresh(Index: integer);
     procedure ReceivedOne(const Text: RawUTF8);
   public
+    {$ifdef WINDOWS}
     MemoBottom: TMemoEx;
+    {$endif}
     destructor Destroy; override;
     property LogFileName: TFileName write SetLogFileName;
   end;
@@ -332,6 +339,7 @@ begin
   ProfileList.ColWidths[0] := 60;
   ProfileList.ColWidths[1] := 1000;
   ProfileList.Hide;
+  {$ifdef WINDOWS}
   MemoBottom := TMemoEx.Create(self);
   MemoBottom.Parent := PanelBottom;
   MemoBottom.Align := alClient;
@@ -342,6 +350,7 @@ begin
   MemoBottom.ReadOnly := true;
   MemoBottom.ScrollBars := ssVertical;
   MemoBottom.Text := '';
+  {$endif}
 end;
 
 procedure TMainLogView.FormShow(Sender: TObject);
@@ -1077,9 +1086,11 @@ end;
 procedure TMainLogView.PanelBottomResize(Sender: TObject);
 var w: integer;
 begin
+  {$ifdef WINDOWS}
   w := MemoBottom.CellRect.Width;
   if w > 0 then
     MemoBottom.RightMargin := (PanelBottom.ClientWidth div w) - 7;
+  {$endif}
 end;
 
 end.

--- a/SQLite3/Samples/36 - Simple REST Benchmark/README.md
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/README.md
@@ -62,3 +62,39 @@ sudo nginx -s reload
 ```
 wrk http://localhost:8888/root/abc
 ```
+
+
+### systemd integration
+
+ - socket activation
+ - journald logging
+ - auto shutdown on inactivity
+
+Once - add our service to systemd
+```
+sudo ./installSystemSocket.sh
+```
+
+Kill possible instances of RESTBenchmark program
+```
+killall -TERM RESTBenchmark
+```
+
+Now program is **NOT running**, lets send an HTTP request
+```
+curl  http://localhost:8888/root/abc
+```
+
+Magik!! We got a response :) This is how systemd socket activation works.
+
+In case program activated by systemd it's designed to 
+ - log all activity into journald
+ - stop after 10 secong without GET requests
+
+Open new termonal window and run a comand to see all new logs for our service
+````
+journalctl -u rest_benchmark.service -f
+```
+
+and wait for 10 second
+

--- a/SQLite3/Samples/36 - Simple REST Benchmark/README.md
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/README.md
@@ -67,22 +67,22 @@ wrk http://localhost:8888/root/abc
 ### systemd integration
 
  - socket activation
- - journald logging
+ - journald logging (can be exported for LogView program)
  - auto shutdown on inactivity
 
 Add our service to systemd (should be executed once).
 This command activate `rest_benchmark` socket on port 8889
-```
+```bash
 sudo ./installSystemSocket.sh
 ```
 
 Kill possible instances of RESTBenchmark program
-```
+```bash
 killall -TERM RESTBenchmark
 ```
 
 Now program is **NOT running**, lets send an HTTP request to a port configured in `rest_benchmark.socket` unit.
-```
+```bash
 curl  http://localhost:8889/root/xyz
 ```
 Magic - we got a response :) This is how systemd socket activation works.
@@ -92,9 +92,16 @@ In case our program is activated by systemd it's designed to
  - stop after 10 seconds without GET requests (see inactivityWatchdog in RESTBenchmark.dpr)
 
 Open new terminal window and run a command to watch logs from `rest_benchmark` services 
-```
+```bash
 journalctl -u rest_benchmark.service -f
 ```
 
-Now wait for 10 second - service should shut down itself. 
+Now wait for 10 second - service should shut down itself.
 
+### journald and LogView (Samples/11 - Exception logging) 
+
+Logs from journald can be exported to format LogView understand. Example:
+```bash
+journalctl -u rest_benchmark.service --no-hostname -o short-iso-precise --since today | grep "RESTBenchmark\[.*\]:  . " > todaysLog.log
+``` 
+better to grep by program PID `"RESTBenchmark\[12345]:  . "` to include only one start/stop circle (on 2020-06 LogView do not allow to filter on PIDs)

--- a/SQLite3/Samples/36 - Simple REST Benchmark/README.md
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/README.md
@@ -39,7 +39,7 @@ in RESTBEnchmark by passing `false` to then second parameter
 
 ### How to run
 
- - compile program and run with `unix` parameter
+ - compile a program and run with `unix` parameter
 ```
 ./RESTBenchmark unix
 ```
@@ -70,7 +70,8 @@ wrk http://localhost:8888/root/abc
  - journald logging
  - auto shutdown on inactivity
 
-Once - add our service to systemd
+Add our service to systemd (should be executed once).
+This command activate `rest_benchmark` socket on port 8889
 ```
 sudo ./installSystemSocket.sh
 ```
@@ -80,21 +81,20 @@ Kill possible instances of RESTBenchmark program
 killall -TERM RESTBenchmark
 ```
 
-Now program is **NOT running**, lets send an HTTP request
+Now program is **NOT running**, lets send an HTTP request to a port configured in `rest_benchmark.socket` unit.
 ```
-curl  http://localhost:8888/root/abc
+curl  http://localhost:8889/root/xyz
 ```
+Magic - we got a response :) This is how systemd socket activation works.
 
-Magik!! We got a response :) This is how systemd socket activation works.
+In case our program is activated by systemd it's designed to 
+ - log all activity into journald (see EchoToConsoleUseJournal)
+ - stop after 10 seconds without GET requests (see inactivityWatchdog in RESTBenchmark.dpr)
 
-In case program activated by systemd it's designed to 
- - log all activity into journald
- - stop after 10 secong without GET requests
-
-Open new termonal window and run a comand to see all new logs for our service
-````
+Open new terminal window and run a command to watch logs from `rest_benchmark` services 
+```
 journalctl -u rest_benchmark.service -f
 ```
 
-and wait for 10 second
+Now wait for 10 second - service should shut down itself. 
 

--- a/SQLite3/Samples/36 - Simple REST Benchmark/README.md
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/README.md
@@ -64,32 +64,37 @@ wrk http://localhost:8888/root/abc
 ```
 
 
-### systemd integration
+## systemd integration
 
  - socket activation
  - journald logging (can be exported for LogView program)
  - auto shutdown on inactivity
 
+With combination of [Systemd Template Unit](https://fedoramagazine.org/systemd-template-unit-files/), `* A` DNS zone and
+nginx virtual hosts we can build a "cloud solution" using mORMot services with per-customer process level isolation.
+    
+### Install Unit    
 Add our service to systemd (should be executed once).
 This command activate `rest_benchmark` socket on port 8889
 ```bash
 sudo ./installSystemSocket.sh
 ```
 
+### Socket activation, auto shutdown and logs 
 Kill possible instances of RESTBenchmark program
 ```bash
 killall -TERM RESTBenchmark
 ```
 
-Now program is **NOT running**, lets send an HTTP request to a port configured in `rest_benchmark.socket` unit.
+Now program is **NOT running**, lets send an HTTP request to a port configured in `rest_benchmark.socket` unit (8889)
 ```bash
 curl  http://localhost:8889/root/xyz
 ```
 Magic - we got a response :) This is how systemd socket activation works.
 
-In case our program is activated by systemd it's designed to 
+Inside our demo program, in case it executed by systemd it:  
  - log all activity into journald (see EchoToConsoleUseJournal)
- - stop after 10 seconds without GET requests (see inactivityWatchdog in RESTBenchmark.dpr)
+ - stops after 10 seconds without GET requests (see inactivityWatchdog in RESTBenchmark.dpr)
 
 Open new terminal window and run a command to watch logs from `rest_benchmark` services 
 ```bash
@@ -105,3 +110,4 @@ Logs from journald can be exported to format LogView understand. Example:
 journalctl -u rest_benchmark.service --no-hostname -o short-iso-precise --since today | grep "RESTBenchmark\[.*\]:  . " > todaysLog.log
 ``` 
 better to grep by program PID `"RESTBenchmark\[12345]:  . "` to include only one start/stop circle (on 2020-06 LogView do not allow to filter on PIDs)
+

--- a/SQLite3/Samples/36 - Simple REST Benchmark/RESTBenchmark.dpr
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/RESTBenchmark.dpr
@@ -12,6 +12,8 @@ program RESTBenchmark;
 {$APPTYPE CONSOLE}
 {$endif}
 
+{$I Synopse.inc} // LINUXNOTBSD
+
 uses
   {$I SynDprUses.inc}  // use FastMM4 on older Delphi, or set FPC threads
   SysUtils,
@@ -22,6 +24,13 @@ uses
   mORMot,              // RESTful server & ORM
   mORMotSQLite3,       // SQLite3 engine as ORM core
   SynSQLite3Static,    // staticaly linked SQLite3 engine
+  {$ifdef UNIX}
+  BaseUnix,
+  {$endif}
+  {$ifdef LINUXNOTBSD}
+  SynSystemd,
+  mORMotService,
+  {$endif}
   mORMotHttpServer;    // HTTP server for RESTful server
 
 type
@@ -102,9 +111,14 @@ begin
   ctxt.Returns(s);
 end;
 
+var
+  url: AnsiString;
+  keepAlive: boolean;
+  aRestServer: TSQLRestServer;
+  lastReadCount: TSynMonitorCount64;
+
 procedure DoTest(const url: AnsiString; keepAlive: boolean);
 var
-  aRestServer: TSQLRestServerDB;
   aHttpServer: TSQLHttpServer;
   aServices: TMyServices;
 begin
@@ -126,8 +140,15 @@ begin
         if (keepAlive) then
           writeLn('is enabled') else
           writeLn('is disabled');
+        {$ifdef LINUX}
+        SynDaemonIntercept(nil);
+        writeln('Press [Ctrl+C] or send SIGINT/SIGTERM to close the server.');
+        while SynDaemonTerminated = 0 do
+          fpPause;
+        {$else}
         write('Press [Enter] to close the server.');
         readln;
+        {$endif}
       finally
         aHttpServer.Free;
       end;
@@ -135,17 +156,30 @@ begin
       aServices.Free;
     end;
   finally
-    aRestServer.Free;
+    FreeAndNil(aRestServer);
   end;
 end;
 
 const
   UNIX_SOCK_PATH = '/tmp/rest-bench.socket';
 
-var
-  url: AnsiString;
-  keepAlive: boolean;
-
+{$ifdef LINUX}
+/// killa process after X second without GEt requests
+function inactivityWatchdog(p: pointer): ptrint;
+var currentRC: TSynMonitorCount64;
+begin
+  repeat
+    currentRC := aRestServer.Stats.Read;
+    if (currentRC - lastReadCount) <= 0 then begin
+      FpKill(GetProcessID, SIGTERM);
+      break;
+    end;
+    lastReadCount := currentRC;
+    sleep(10000); /// once per 10 second
+  until false;
+  Result := 0;
+end;
+{$endif}
 begin
   // set logging abilities
   SQLite3Log.Family.Level := LOG_VERBOSE;
@@ -153,6 +187,20 @@ begin
   SQLite3Log.Family.PerThreadLog := ptIdentifiedInOnFile;
   SQLite3Log.Family.NoFile := true; // do not create log files for benchmark
   {$ifdef UNIX}
+  {$ifdef LINUXNOTBSD}
+  if SynSystemd.ProcessIsStartedBySystemd then begin
+    SQLite3Log.Family.EchoToConsole := SQLite3Log.Family.Level;
+    SQLite3Log.Family.EchoToConsoleUseJournal := true;
+    if sd.listen_fds(0) = 1 then
+      url := '' // force to use socket passed by systemd
+    else
+      url := '8888';
+    // set a wachdog to kill our process after 10 sec of inactivity
+    // just for demo - in real life verifiing only read operations is not enought
+    lastReadCount := 0;
+    BeginThread(@inactivityWatchdog, nil);
+  end else
+  {$endif}
   if (ParamCount>0) and (ParamStr(1)='unix') then begin
     url := 'unix:' + UNIX_SOCK_PATH;
     if FileExists(UNIX_SOCK_PATH) then

--- a/SQLite3/Samples/36 - Simple REST Benchmark/RESTBenchmark.lpi
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/RESTBenchmark.lpi
@@ -39,6 +39,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="../..;../../..;$(ProjOutDir;$(ProjOutDir)"/>
+      <Libraries Value="../../../static/$(TargetCPU)-$(TargetOS)"/>
       <OtherUnitFiles Value="../..;../../.."/>
       <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>

--- a/SQLite3/Samples/36 - Simple REST Benchmark/installSystemSocket.sh
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/installSystemSocket.sh
@@ -1,0 +1,5 @@
+ln -s "`pwd`/rest_benchmark.socket" /etc/systemd/system
+ln -s "`pwd`/rest_benchmark.service" /etc/systemd/system
+systemctl enable rest_benchmark.socket
+systemctl start rest_benchmark.socket
+systemctl status rest_benchmark.socket #output status to console

--- a/SQLite3/Samples/36 - Simple REST Benchmark/rest_benchmark.service
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/rest_benchmark.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=mORMot socket activation demo
+Documentation=https://synopse.info
+RefuseManualStart=true
+
+[Service]
+Restart=on-failure
+ExecStart="/home/pavelmash/dev/tmp/crypto_ssl/mORMot/SQLite3/Samples/36 - Simple REST Benchmark/RESTBenchmark"
+# starting from systemd v244 is possible to configure log limits per service as below
+# befote - only inside journald.conf
+# LogRateLimitIntervalSec=1s
+# LogRateLimitBurst=50000 # ~10 000 req / sec

--- a/SQLite3/Samples/36 - Simple REST Benchmark/rest_benchmark.socket
+++ b/SQLite3/Samples/36 - Simple REST Benchmark/rest_benchmark.socket
@@ -1,0 +1,7 @@
+[Socket]
+ListenStream=127.0.0.1:8889
+NoDelay=true
+KeepAlive=true
+ 
+[Install]
+WantedBy=sockets.target

--- a/SynBidirSock.pas
+++ b/SynBidirSock.pas
@@ -1072,7 +1072,8 @@ type
     // once it has been upgraded to WebSockets
     constructor Create(const aPort: SockString; OnStart,OnStop: TNotifyThreadEvent;
       const ProcessName: SockString; ServerThreadPoolCount: integer=2;
-      KeepAliveTimeOut: integer=30000; HeadersNotFiltered: boolean=false); override;
+      KeepAliveTimeOut: integer=30000; HeadersNotFiltered: boolean=false;
+      CreateSuspended: boolean = false); override;
     /// close the server
     destructor Destroy; override;
     /// will send a given frame to all connected clients
@@ -3153,7 +3154,7 @@ end;
 
 constructor TWebSocketServer.Create(const aPort: SockString; OnStart,OnStop: TNotifyThreadEvent;
   const ProcessName: SockString; ServerThreadPoolCount, KeepAliveTimeOut: integer;
-  HeadersNotFiltered: boolean);
+  HeadersNotFiltered: boolean; CreateSuspended: boolean);
 begin
   // override with custom processing classes
   fSocketClass := TWebSocketServerSocket;
@@ -3166,7 +3167,7 @@ begin
   fCanNotifyCallback := true;
   // start the server
   inherited Create(aPort,OnStart,OnStop,ProcessName,ServerThreadPoolCount,
-    KeepAliveTimeOut,HeadersNotFiltered);
+    KeepAliveTimeOut,HeadersNotFiltered,CreateSuspended);
 end;
 
 function TWebSocketServer.WebSocketProcessUpgrade(ClientSock: THttpServerSocket;

--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -6413,6 +6413,13 @@ begin
   // main server process loop
   try
     fSock := TCrtSocket.Bind(fSockPort); // BIND + LISTEN
+    {$ifdef LINUXNOTBSD}
+    // in case we started by systemd, listening socket is created by another process
+    // and do not interrupt while process got a signal. So we need to set a timeout to
+    // unblock accept() periodically and check we need terminations
+    if fSockPort = '' then // external socket
+      fSock.ReceiveTimeout := 1000; // unblock accept every second
+    {$endif}
     fExecuteState := esRunning;
     if fSock.Sock<=0 then // paranoid (Bind would have raise an exception)
       raise ECrtSocket.Create('THttpServer.Execute: TCrtSocket.Bind failed');

--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -286,12 +286,12 @@ type
     // Windows by now, using the SChannel API)
     constructor Open(const aServer, aPort: SockString; aLayer: TCrtSocketLayer=cslTCP;
       aTimeOut: cardinal=10000; aTLS: boolean=false);
-    /// bind to a Port
-    // - expects the port to be specified as Ansi string, e.g. '1234'
-    // - you can optionally specify a server address to bind to, e.g.
-    // '1.2.3.4:1234'
-    // - for unix domain socket use unix:/path/to/file
-    constructor Bind(const aPort: SockString; aLayer: TCrtSocketLayer=cslTCP);
+    /// bind to an address. Expects the address to be specified as Ansi string as
+    // - '1234' - bind to a port on all interfaces, the same as '0.0.0.0:1234'
+    // - 'IP:port' - bind to specified interface only, e.g. '1.2.3.4:1234'
+    // - 'unix:/path/to/file' - bind to unix domain socket, e.g. 'unix:/run/mormot.sock'
+    // - '' - bind to systemd descriptor on linux. See http://0pointer.de/blog/projects/socket-activation.html
+    constructor Bind(const anAddr: SockString; aLayer: TCrtSocketLayer=cslTCP);
     /// low-level internal method called by Open() and Bind() constructors
     // - raise an ECrtSocket exception on error
     // - you may ask for a TLS secured client connection (only available under
@@ -361,7 +361,7 @@ type
     procedure SockSend(P: pointer; Len: integer); overload;
     /// flush all pending data to be sent, optionally with some body content
     // - raise ECrtSocket on error
-    procedure SockSendFlush(const aBody: SockString='');
+    procedure SockSendFlush(const aBody: SockString=''); virtual;
     /// flush all pending data to be sent
     // - returning true on success
     function TrySockSendFlush: boolean;
@@ -1879,6 +1879,10 @@ type
     // - this constructor will raise a EHttpServer exception if binding failed
     // - expects the port to be specified as string, e.g. '1234'; you can
     // optionally specify a server address to bind to, e.g. '1.2.3.4:1234'
+    // - can listed on UDS in case port is specified with 'unix:' prefix, e.g.
+    // 'unix:/run/myapp.sock'
+    // - on Linux in case aPort is empty string will check if external fd
+    // is passed by systemd and use it (so called systemd socked activation)
     // - you can specify a number of threads to be initialized to handle
     // incoming connections. Default is 32, which may be sufficient for most
     // cases, maximum is 256. If you set 0, the thread pool will be disabled
@@ -1890,7 +1894,8 @@ type
     // THttpServer.Create()
     constructor Create(const aPort: SockString; OnStart,OnStop: TNotifyThreadEvent;
       const ProcessName: SockString; ServerThreadPoolCount: integer=32;
-      KeepAliveTimeOut: integer=30000; HeadersUnFiltered: boolean=false); reintroduce; virtual;
+      KeepAliveTimeOut: integer=30000; HeadersUnFiltered: boolean=false;
+      CreateSuspended: boolean = false); reintroduce; virtual;
     /// ensure the HTTP server thread is actually bound to the specified port
     // - TCrtSocket.Bind() occurs in the background in the Execute method: you
     // should call and check this method result just after THttpServer.Create
@@ -3227,6 +3232,11 @@ var
 
 
 implementation
+
+{$ifdef LINUXNOTBSD}
+uses
+  SynSystemd;
+{$endif}
 
 { ************ some shared helper functions and classes }
 
@@ -4920,13 +4930,30 @@ begin
   result := false;
 end;
 
-constructor TCrtSocket.Bind(const aPort: SockString; aLayer: TCrtSocketLayer);
+constructor TCrtSocket.Bind(const anAddr: SockString; aLayer: TCrtSocketLayer);
 var s,p: SockString;
+    aSock: integer;
+    {$ifdef LINUXNOTBSD}
+    n: integer;
+    {$endif}
 begin
   Create(10000);
-  if not Split(aPort,':',s,p) then begin
+  if anAddr = '' then begin // try systemd
+    {$ifdef LINUXNOTBSD}
+    if not SystemdIsAvailable then
+      raise ECrtSocket.Create('Systemd is not available but empty address is passed to bind');
+    n := sd.listen_fds(0);
+    if (n > 1) then
+      raise ECrtSocket.Create('Systemd activation fails - too many file descriptors received');
+    aSock := SD_LISTEN_FDS_START + 0;
+    {$else}
+    raise ECrtSocket.Create('Can''t bind to empty address');
+    {$endif}
+  end else begin
+    aSock := -1; // force OpenBind to create listening socket
+    if not Split(anAddr,':',s,p) then begin
     s := '0.0.0.0';
-    p := aPort;
+      p := anAddr;
   end;
   {$ifndef MSWINDOWS}
   if s='unix' then begin
@@ -4935,7 +4962,8 @@ begin
     p := '';
   end;
   {$endif}
-  OpenBind(s,p,{dobind=}true,-1,aLayer); // raise a ECrtSocket on error
+  end;
+  OpenBind(s,p,{dobind=}true,aSock,aLayer); // raise a ECrtSocket on error
 end;
 
 constructor TCrtSocket.Open(const aServer, aPort: SockString; aLayer: TCrtSocketLayer;
@@ -4966,6 +4994,12 @@ begin
   end;
   if fSock<=0 then
     exit; // no opened connection, or Close already executed
+  {$ifdef LINUXNOTBSD}
+  if (fWasBind and (fPort='')) then begin // binded on external socket
+    fSock := -1;
+    exit;
+  end;
+  {$endif}
   {$ifdef MSWINDOWS}
   if fSecure.Initialized then
     fSecure.BeforeDisconnection(fSock);
@@ -5018,8 +5052,10 @@ begin
     SendTimeout := TimeOut;
   end;
   if aLayer=cslTCP then begin
-    TCPNoDelay := 1; // disable Nagle algorithm since we use our own buffers
-    KeepAlive := 1; // enable TCP keepalive (even if we rely on transport layer)
+    if (aSock<0) or ((aSock>0) and not doBind) then begin // do not touch externally created socket
+      TCPNoDelay := 1; // disable Nagle algorithm since we use our own buffers
+      KeepAlive := 1; // enable TCP keepalive (even if we rely on transport layer)
+    end;
     if aTLS and (aSock<=0) and not doBind then
       try
         {$ifdef MSWINDOWS}
@@ -6196,7 +6232,7 @@ end;
 constructor THttpServer.Create(const aPort: SockString; OnStart,
   OnStop: TNotifyThreadEvent; const ProcessName: SockString;
   ServerThreadPoolCount: integer; KeepAliveTimeOut: integer;
-  HeadersUnFiltered: boolean);
+  HeadersUnFiltered: boolean; CreateSuspended: boolean);
 begin
   fSockPort := aPort;
   fInternalHttpServerRespList := {$ifdef FPC}TFPList{$else}TList{$endif}.Create;
@@ -6216,7 +6252,7 @@ begin
     fHTTPQueueLength := 1000;
   end;
   fHeadersNotFiltered := HeadersUnFiltered;
-  inherited Create(false,OnStart,OnStop,ProcessName);
+  inherited Create(CreateSuspended,OnStart,OnStop,ProcessName);
 end;
 
 function THttpServer.GetAPIVersion: string;

--- a/SynLog.pas
+++ b/SynLog.pas
@@ -577,7 +577,7 @@ type
     // into journald service.
     // - such logs can exported in format what can be viewed by LogView tool using
     // a command (raplace UNIT with your unit name and PROCESS with executable name):
-    // "journalctl -u UNIT --no-hostname -o short-iso-precise --since today | grep "PROCESS\[.*\]:   . " > todaysLog.log"
+    // "journalctl -u UNIT --no-hostname -o short-iso-precise --since today | grep "PROCESS\[.*\]:  . " > todaysLog.log"
     property EchoToConsoleUseJournal: boolean read fEchoToConsoleUseJournal
       write SetEchoToConsoleUseJournal;
     /// can be set to a callback which will be called for each log line
@@ -5417,7 +5417,7 @@ begin
       p := PosChar(LineBeg, ']'); //time proc[pid]:
       if p = nil then
         exit; // not a log
-      fLineLevelOffset := (p - LineBeg) + 5; // ":   " for :
+      fLineLevelOffset := (p - LineBeg) + 4; // ":  "
       fDayCurrent := PInt64(LineBeg+dcOffset)^;
     end else if LineBeg[8]=' ' then begin
       // YYYYMMDD HHMMSS is one char bigger than Timestamp

--- a/SynSystemd.pas
+++ b/SynSystemd.pas
@@ -1,0 +1,151 @@
+/// curl library direct access classes
+// - this unit is a part of the freeware Synopse framework,
+// licensed under a MPL/GPL/LGPL tri-license; version 1.18
+unit SynSystemd;
+
+{
+  *****************************************************************************
+   Access to SystemD features for modern Linux using libsystemd
+
+   Features:
+    - a building block for THTTPServer socket activation
+
+   Limitations:
+    - Linux only
+
+  *****************************************************************************
+}
+
+interface
+
+{$I Synopse.inc} // define HASINLINE CPU32 CPU64 OWNNORMTOUPPER
+
+uses
+  {$ifndef LINUXNOTBSD}
+  // SynSystemD is for Linux only
+  {$endif}
+  SysUtils,
+  SynCommons;
+
+const
+  /// The first passed file descriptor is fd 3
+  SD_LISTEN_FDS_START = 3;
+  /// low-level libcurl library file name, depending on the running OS
+  LIBSYSTEMD_PATH = 'libsystemd.so.0';
+  ENV_INVOCATION_ID = 'INVOCATION_ID';
+
+type
+  /// low-level exception raised during systemd library access
+  ESystemd = class(Exception);
+
+var
+  /// low-level late binding functions access to the systemd library API
+  // - ensure you called LibSystemdInitialize or SystemdIsAvailable functions to
+  // setup this global instance before using any of its internal functions
+  // - see also https://www.freedesktop.org/wiki/Software/systemd/
+  // and http://0pointer.de/blog/projects/socket-activation.html
+  // - to get a headers on debian - `sudo apt install libsystemd-dev && cd /usr/include/systemd`
+  sd: packed record
+    /// hold a reference to the loaded library
+    // - PtrInt(Module)=0 before initialization, or PtrInt(Module) = -1
+    // on initialization failure, or PtrInt(Module)>0 if loaded
+    {$ifdef FPC}
+    Module: TLibHandle;
+    {$else}
+    Module: THandle;
+    {$endif FPC}
+    /// returns how many file descriptors have been passed to process.
+    // If result=1 then socket for accepting connection is SD_LISTEN_FDS_START
+    listen_fds: function(unset_environment: integer): integer; cdecl;
+    /// returns 1 if the file descriptor is an AF_UNIX socket of the specified type and path
+    is_socket_unix: function(fd, typr, listening: integer;
+      var path: TFileName; pathLength: PtrUInt): integer; cdecl;
+    /// submit simple, plain text log entries to the system journal
+    // priority can be obtained using longint(LOG_TO_SYSLOG[logLevel])
+    journal_print: function(priority: longint; args: array of const): longint; cdecl;
+    /// sends notification to systemd. See https://www.freedesktop.org/software/systemd/man/sd_notify.html
+    // status notification sample: sd.notify(0, 'READY=1');
+    // watchdog notification: sd.notify(0, 'WATCHDOG=1');
+    notify: function(unset_environment: longint; state: PUTF8Char): longint; cdecl;
+    /// check whether the service manager expects watchdog keep-alive notifications from a service
+    // If result > 0 then usec contains notification interval (app should notify every usec\2 uniseconds)
+    watchdog_enabled: function(unset_environment: longint; usec: Puint64): longint; cdecl;
+  end;
+
+/// return TRUE if a systemd library is available
+// - will load and initialize it, calling LibSystemdInitialize if necessary,
+// catching any exception during the process
+function SystemdIsAvailable: boolean;
+
+/// Return true in case process is started by systemd
+// For systemd v232+
+function ProcessIsStartedBySystemd: boolean;
+
+/// initialize the libsystemd API
+// - do nothing if the library has already been loaded
+// - will raise ESsytemd exception on any loading issue
+procedure LibSystemdInitialize(const libname: TFileName=LIBSYSTEMD_PATH);
+
+implementation
+
+uses
+  BaseUnix,
+  SynFPCSock; // SynSockCS
+
+function SystemdIsAvailable: boolean;
+begin
+  try
+    if sd.Module=0 then
+      LibSystemdInitialize;
+    result := PtrInt(sd.Module)>0;
+  except
+    result := false;
+  end;
+end;
+
+function ProcessIsStartedBySystemd: boolean;
+begin
+  if not SystemdIsAvailable then
+    exit(false);
+  Result := fpGetenv(ENV_INVOCATION_ID) <> nil;
+end;
+
+procedure LibSystemdInitialize(const libname: TFileName);
+var P: PPointer;
+    api: integer;
+    h: {$ifdef FPC}TLibHandle{$else}THandle{$endif FPC};
+const NAMES: array[0..4] of string = (
+  'sd_listen_fds', 'sd_is_socket_unix', 'sd_journal_print', 'sd_notify', 'sd_watchdog_enabled');
+begin
+  EnterCriticalSection(SynSockCS);
+  try
+    if sd.Module=0 then // try to load once
+    try
+      h := LoadLibrary(libname);
+      P := @@sd.listen_fds;
+      for api := low(NAMES) to high(NAMES) do begin
+        P^ := GetProcAddress(h,PChar(NAMES[api]));
+        if P^=nil then
+          raise ESystemd.CreateFmt('Unable to find %s() in %s',[NAMES[api],libname]);
+        inc(P);
+      end;
+      sd.Module := h;
+    except
+      on E: Exception do begin
+        if h<>0 then
+          FreeLibrary(h);
+        PtrInt(sd.Module) := -1; // <>0 so that won't try to load any more
+        raise;
+      end;
+    end;
+  finally
+    LeaveCriticalSection(SynSockCS);
+  end;
+end;
+
+finalization
+  if PtrInt(sd.Module) > 0 then begin
+    FreeLibrary(sd.Module);
+  end;
+end.
+

--- a/SynSystemd.pas
+++ b/SynSystemd.pas
@@ -107,7 +107,10 @@ function ProcessIsStartedBySystemd: boolean;
 begin
   if not SystemdIsAvailable then
     exit(false);
-  Result := fpGetenv(ENV_INVOCATION_ID) <> nil;
+  // note: for example on Ubuntu 20.04 INVOCATION_ID is always defined
+  // from the other side PPID 1 can be in case we run under docker of started by init.d
+  // so let's verify both
+  Result := (fpgetppid() = 1) and (fpGetenv(ENV_INVOCATION_ID) <> nil);
 end;
 
 procedure LibSystemdInitialize(const libname: TFileName);

--- a/build-fpc-linux64.sh
+++ b/build-fpc-linux64.sh
@@ -4,4 +4,4 @@ rm -rf ./fpc/*
 mkdir -p ./fpc/lib/x86_64-linux
 mkdir -p ./fpc/bin/x86_64-linux
 
-fpc -B -MObjFPC -Scagi -Cg -Cirot -gw2 -gl -l -dFPCSQLITE3STATIC -dUseCThreads -Fi -Fifpc/lib/x86_64-linux -Fl./fpc-linux64 -Fu./SQLite3 -Fu./SQLite3/DDD/dom -Fu./SQLite3/DDD/infra "-Fu./SQLite3/Samples/33 - ECC" -Fu. -FUfpc/lib/x86_64-linux -FEfpc/bin/x86_64-linux/ ./SQLite3/TestSQL3.dpr
+fpc.sh -B -MObjFPC -Scagi -Cg -Cirot -gw2 -gl -l -dFPCSQLITE3STATIC -dUseCThreads -Fi -Fifpc/lib/x86_64-linux -Fl./fpc-linux64 -Fu./SQLite3 -Fu./SQLite3/DDD/dom -Fu./SQLite3/DDD/infra "-Fu./SQLite3/Samples/33 - ECC" -Fu. -FUfpc/lib/x86_64-linux -FEfpc/bin/x86_64-linux/ ./SQLite3/TestSQL3.dpr


### PR DESCRIPTION
Systemd integration:
 - **adedd** export required libsystemd functions (new unit `SynSystemd.pas`)
 - **added** THTTPServer now able to use externally created listening socket
 - **added** SynLog can echo directly into journald (with log level support) - new property `TSynLogFamily.EchoToConsoleUseJournal`
 - **added** samples 36 is extended to show a systemd socket activation (see SQLite3/Samples/36 - Simple REST Benchmark/README.md)
 - **added** LogView understand some kind of journald export (limited for a while by singe PID)
 - **fixed** LogView program can be compiled under Linux
 - **fixed** `createSuspended` parameter added into THttpServer constructor (in real app server should be created in suspended state to allow configure it properties before accepting client requests)
- I mark a TCrtSock.SockSendFlush as virtual to allow override it in descendants. For example it's allow me to create a "fake" socket and push it to `ThreadPool.Push(fakeSocket)`