### PR TITLE
**CRITICAL** ExistNameValue should return nil 

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -3724,7 +3724,7 @@ begin
       inc(result);
     while result^<=#13 do
       if result^=#0 then
-        exit else
+        exit(nil) else
         inc(result);
   until false;
 end;


### PR DESCRIPTION
ExistNameValue should return nil in case name not found (as expected by callers) but instead returns #0.
Issue introduced by [bde936aecd]
Without fix GetHeaderValue returns random result in case header does not exists