### PR TITLE
Socket based HTTP server 10 second delay for req with empty body

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -6863,18 +6863,10 @@ begin
     SetLength(Content,ContentLength); // not chuncked: direct read
     SockInRead(pointer(Content),ContentLength); // works with SockIn=nil or not
   end else
-  if ContentLength<0 then begin // ContentLength=-1 if no Content-Length
-    // no Content-Length nor Chunked header -> read until eof()
-    if SockIn<>nil then
-      while not eof(SockIn^) do begin
-        readln(SockIn^,Line);
-        if Content='' then
-          Content := Line else
-          Content := Content+#13#10+Line;
-      end;
-    ContentLength := length(Content); // update Content-Length
-    exit;
-  end;
+    // no transferChuked or Content-Length - no body
+    // see https://greenbytes.de/tech/webdav/rfc7230.html#message.body.length
+    // TODO Transfer-Encoding: gzip, chunked
+    ContentLength := 0;
   // optionaly uncompress content
   if cardinal(fContentCompress)<cardinal(length(fCompress)) then
     if fCompress[fContentCompress].Func(Content,false)='' then


### PR DESCRIPTION
If neither Content-Length nor Transfer-Encoding: chunked header present we should not try to read HTTP body - see https://greenbytes.de/tech/webdav/rfc7230.html#message.body.length

In other case we got a 10 second delay in case on non keep-alive requests:
```
curl -v 'http://localhost:8881/root/timestamp' -X OPTIONS --compressed -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: authorization,content-type' -H 'Referer: http://localhost:6060/' -H 'Origin: http://localhost:8881' -H 'DNT: 1' -H 'Connection: Close'
```