### PR TITLE
fixed FindFiles sub-folders search under Windows

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -30915,7 +30915,7 @@ end;
 
 function SearchRecValidFolder(const F: TSearchRec): boolean;
 begin
-  result := (F.Attr and (faDirectory {$ifdef MSWINDOWS}and faHidden{$endif})=faDirectory) and
+  result := (F.Attr and (faDirectory {$ifdef MSWINDOWS}+faHidden{$endif})=faDirectory) and
     (F.Name<>'') and (F.Name<>'.') and (F.Name<>'..');
 end;
 


### PR DESCRIPTION
```Delphi
(F.Attr and (faDirectory {$ifdef MSWINDOWS}and faHidden{$endif})=faDirectory)
```
Always return `False` (due to `faDirectory and faHidden = 0` under Windows).
This bug is preventing any search in subfolders.