### PR TITLE
ExternalLibraries.sd_journal_sendv used instead of sd_journal_print

### DIFF
--- a/SynFPCLinux.pas
+++ b/SynFPCLinux.pas
@@ -61,6 +61,7 @@ interface
 
 uses
   {$ifdef LINUX}
+  BaseUnix,
   UnixType,
   {$endif LINUX}
   SysUtils;
@@ -254,7 +255,13 @@ type
       var path: TFileName; pathLength: PtrUInt): integer; cdecl;
     /// systemd: submit simple, plain text log entries to the system journal
     // - priority value can be obtained using longint(LOG_TO_SYSLOG[logLevel])
+    // - WARNING: args strings processed using C printf semantic, so % is a printf placeholder
+    //   and should be either escaped using %% or all formatting args must be passed
     sd_journal_print: function(priority: longint; args: array of const): longint; cdecl;
+    /// systemd: submit array of iov structures instead of the format string to the system journal.
+    //  - each structure should reference one field of the entry to submit.
+    //  - the second argument specifies the number of structures in the array.
+    sd_journal_sendv: function(const iov : Piovec; n: longint): longint; cdecl;
     /// systemd: sends notification to systemd
     // - see https://www.freedesktop.org/software/systemd/man/sd_notify.html
     // status notification sample: sd.notify(0, 'READY=1');
@@ -315,7 +322,6 @@ implementation
 uses
   Classes,
   Unix,
-  BaseUnix,
   {$ifdef BSD}
   sysctl,
   {$else}
@@ -737,8 +743,8 @@ var
   p: PPointer;
   i, j: integer;
 const
-  NAMES: array[0..4] of PAnsiChar = (
-    'sd_listen_fds', 'sd_is_socket_unix', 'sd_journal_print',
+  NAMES: array[0..5] of PAnsiChar = (
+    'sd_listen_fds', 'sd_is_socket_unix', 'sd_journal_print', 'sd_journal_sendv',
     'sd_notify', 'sd_watchdog_enabled');
 begin
   if lib in Loaded then

--- a/SynLog.pas
+++ b/SynLog.pas
@@ -4114,16 +4114,27 @@ function TSynLog.ConsoleEcho(Sender: TTextWriter; Level: TSynLogInfo;
 {$ifdef MSWINDOWS}
 var tmp: AnsiString;
 {$endif}
+{$ifdef LINUXNOTBSD}
+var
+  tmp, mtmp: RawUTF8;
+  jvec: Array[0..1] of TioVec;
+{$endif}
 begin
   result := true;
   if not (Level in fFamily.fEchoToConsole) then
     exit;
   {$ifdef LINUXNOTBSD}
   if Family.EchoToConsoleUseJournal then begin
+    if length(Text)<18 then // should be at last "20200615 08003008  "
+      exit;
+    tmp := FormatUTF8('PRIORITY=%', [LOG_TO_SYSLOG[Level]]);
+    jvec[0].iov_base := pointer(tmp);
+    jvec[0].iov_len := length(tmp);
     // skip time "20200615 08003008  ." - journal do it for us; and first space after it
-    if length(Text)>18 then
-      ExternalLibraries.sd_journal_print(longint(LOG_TO_SYSLOG[Level]),
-        [PUTF8Char(pointer(Text))+18]);
+    mtmp := FormatUTF8('MESSAGE=%', [PUTF8Char(pointer(Text))+18]);
+    jvec[1].iov_base := pointer(mtmp);
+    jvec[1].iov_len := length(mtmp);
+    ExternalLibraries.sd_journal_sendv(@jvec[0], 2);
     exit;
   end;
   {$endif}


### PR DESCRIPTION
- added `ExternalLibraries.sd_journal_sendv`
- `ExternalLibraries.sd_journal_sendv` used instead of sd_journal_print to log into journald, because sd_journal_print expect % in message to be a printf format string (% is a placeholder), but SynLog message can contains % inside (for example thread #4 = %)