### PR TITLE
log view for files w/o header

### DIFF
--- a/SQLite3/Samples/11 - Exception logging/LogViewMain.pas
+++ b/SQLite3/Samples/11 - Exception logging/LogViewMain.pas
@@ -358,7 +358,7 @@ end;
 procedure TMainLogView.FormShow(Sender: TObject);
 var CmdLine: TFileName;
 begin
-  PanelThread.Width := 300;
+  PanelThread.Width := 200;
   if ParamCount>0 then begin
     CmdLine := ParamStr(1);
     if SysUtils.DirectoryExists(CmdLine) then begin

--- a/SynLog.pas
+++ b/SynLog.pas
@@ -5136,8 +5136,9 @@ begin
   end else begin
     //2020-06-18T13:28:20.754089+0300 ub[12316]:
     Iso8601ToDateTimePUTF8CharVar(pointer(fMap.Buffer),26,fStartDateTime);
-    if fStartDateTime > 0 then begin
-      fIsJournald := true;
+    if unaligned(fStartDateTime) <> 0 then begin
+      if (fMap.Buffer+8)^ <> ' ' then //20200821 14450738 ... - syn log without header
+        fIsJournald := true;
       fHeaderLinesCount := 0;
       fLineHeaderCountToIgnore := 0;
     end;
@@ -5146,8 +5147,8 @@ begin
   // 2. fast retrieval of header
   OK := false;
   try
-    // journald export
-    if fIsJournald then begin
+    // journald export or TSynLog WITHOUT regular header
+    if fIsJournald or (fLineHeaderCountToIgnore=0) then begin
       if LineSizeSmallerThan(1,34) then exit;
       Iso8601ToDateTimePUTF8CharVar(fLines[1],26,fStartDateTime);
       if fStartDateTime=0 then


### PR DESCRIPTION
LogView improvements:
 - decrease thread panel width to 200px (maximize log space)
 - recognize regular TSynLog file without header (header can be removed for security reason)

