### PR TITLE
lets accepted socket inherit timeout value from binded one

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -5232,7 +5232,7 @@ begin
     exit;
   if ResultClass=nil then
     ResultClass := TCrtSocket;
-  result := ResultClass.Create;
+  result := ResultClass.Create(Timeout);
   result.AcceptRequest(client,@sin);
   result.CreateSockIn; // use SockIn with 1KB input buffer: 2x faster
 end;


### PR DESCRIPTION
This fix a situation 
```
 ServerSock := TCrtSocket.Bind(fPort, cslTCP, 0); // set timeout to 0 to wait on read loop until closed
 AcceptedSocket := ServerSock.AcceptIncoming(); // AcceptedSocket.timeout is 10000 (default) but should be 0
```
(the same patch added for mORMot2)