### PR TITLE
added share interface support for LibCurl

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -11906,6 +11906,8 @@ begin
   if not IsAvailable then
     raise ECrtSocket.CreateFmt('No available %s',[LIBCURL_DLL]);
   fHandle := curl.easy_init;
+  if curl.globalShare <> nil then
+    curl.easy_setopt(fHandle, coShare, curl.globalShare);
   ConnectionTimeOut := ConnectionTimeOut div 1000; // curl expects seconds
   if ConnectionTimeOut=0 then
     ConnectionTimeOut := 1;

--- a/SynCurl.pas
+++ b/SynCurl.pas
@@ -243,6 +243,22 @@ type
     crTFTPDiskFull, crTFTPIllegal, crTFTPUnknownID, crTFTPExists, crTFTPNoSuchUser
   );
 
+  CURLSHcode = (CURLSHE_OK,           // all is fine
+                CURLSHE_BAD_OPTION,   // 1
+                CURLSHE_IN_USE,       // 2
+                CURLSHE_INVALID,      // 3
+                CURLSHE_NOMEM,        // 4 out of memory
+                CURLSHE_NOT_BUILT_IN, // 5 feature not present in lib
+                CURLSHE_LAST);        // never use
+
+  CURLSHoption = (CURLSHOPT_NONE,
+                  CURLSHOPT_SHARE,
+                  CURLSHOPT_UNSHARE,
+                  CURLSHOPT_LOCKFUNC,
+                  CURLSHOPT_UNLOCKFUNC,
+                  CURLSHOPT_USERDATA,
+                  CURLSHOPT_LAST);
+
   /// low-level information enumeration for libcurl library API calls
   TCurlInfo = (
     ciNone,
@@ -357,6 +373,7 @@ type
   /// low-level string list type for libcurl library API
   TCurlSList = type pointer;
   PCurlSList = ^TCurlSList;
+  TCurlShare = type pointer;
   PPCurlSListArray = ^PCurlSListArray;
   PCurlSListArray = array[0..(MaxInt div SizeOf(PCurlSList))-1] of PCurlSList;
   /// low-level access to the libcurl library instance in "multi" mode
@@ -400,6 +417,26 @@ type
   curl_read_callback = function (buffer: PAnsiChar; size,nitems: integer;
     instream: pointer): integer; cdecl;
 
+  curl_lock_data = (CURL_LOCK_DATA_NONE = 0,
+                    CURL_LOCK_DATA_SHARE,
+                    CURL_LOCK_DATA_COOKIE,
+                    CURL_LOCK_DATA_DNS,
+                    CURL_LOCK_DATA_SSL_SESSION,
+                    CURL_LOCK_DATA_CONNECT,
+                    CURL_LOCK_DATA_PSL,
+                    CURL_LOCK_DATA_LAST);
+
+  curl_lock_access = (CURL_LOCK_ACCESS_NONE = 0,
+                      CURL_LOCK_ACCESS_SHARED = 1,
+                      CURL_LOCK_ACCESS_SINGLE = 2,
+                      CURL_LOCK_ACCESS_LAST);
+
+  /// lock function signature for CURLSHOPT_LOCKFUNC
+  curl_lock_function = procedure (handle: TCurl; data: curl_lock_data;
+    locktype: curl_lock_access; userptr: pointer); cdecl;
+  /// unlock function signature for CURLSHOPT_UNLOCKFUNC
+  curl_unlock_function = procedure (handle: TCurl; data: curl_lock_data;
+    userptr: pointer); cdecl;
 {$Z1}
 
 
@@ -417,6 +454,11 @@ var
     {$else}
     Module: THandle;
     {$endif FPC}
+    /// in case CurlEnableShare is called this array holds a
+    // critical section per curl_lock_data
+    share_cs: array[0..Ord(CURL_LOCK_DATA_PSL)] of TRTLCriticalSection;
+    /// global TCurlShare object
+    globalShare: TCurlShare;
     /// initialize the library
     global_init: function(flags: TCurlGlobalInit): TCurlResult; cdecl;
     /// finalize the library
@@ -443,7 +485,15 @@ var
     slist_append: function(list: TCurlSList; s: PAnsiChar): TCurlSList; cdecl;
     /// free an entire slist
     slist_free_all: procedure(list: TCurlSList); cdecl;
-    {$ifdef LIBCURLMULTI}
+    /// create a shared object
+    share_init: function: pointer; cdecl;
+    /// clean up a shared object
+    share_cleanup: function(share_handle: TCurlShare): CURLSHcode; cdecl;
+    /// set options for a shared object
+    share_setopt: function(share: TCurlShare; option: CURLSHoption): CURLSHcode; cdecl varargs;
+    /// return string describing error code
+    share_strerror: function(code: CURLSHcode): PAnsiChar; cdecl;
+    {$ifdef LIBCURLMULTI}                               12
     /// add an easy handle to a multi session
     multi_add_handle: function(mcurl: TCurlMulti; curl: TCurl): TCurlMultiCode; cdecl;
     /// set data to associate with an internal socket
@@ -498,6 +548,18 @@ function CurlIsAvailable: boolean;
 function CurlWriteRawByteString(buffer: PAnsiChar; size,nitems: integer;
   opaque: pointer): integer; cdecl;
 
+/// This function enable multiple easy handles share data between them.
+// Shared objects are - DNS cache, TLS session cache and connection cache
+// This way, each single transfer will take advantage from data updates made by the other transfer(s)
+// see https://curl.se/libcurl/c/libcurl-share.html for details
+function CurlEnableGlobalShare: boolean;
+
+/// Disable a global share for libcurtl.
+// This function is called automatically in finalization section.
+// In case it called manually ensure there is no active HTTP requests
+// to prevent CURLSHE_IN_USE error
+function CurlDisableGlbalShare: CURLSHcode;
+
 implementation
 
 {$ifdef LIBCURLSTATIC}
@@ -538,6 +600,14 @@ implementation
   function curl_slist_append(list: TCurlSList; s: PAnsiChar): TCurlSList; cdecl; external;
   /// free an entire slist
   procedure curl_slist_free_all(list: TCurlSList); cdecl; external;
+  /// create a shared object
+  function curl_share_init: pointer; cdecl; external
+  /// clean up a shared object
+  function curl_share_cleanup(share_handle: TCurlShare): CURLSHcode; cdecl; external;
+  /// set options for a shared object
+  function curl_share_setopt(share: TCurlShare; option: CURLSHoption): CURLSHcode; cdecl varargs; external;
+  /// return string describing error code
+  function curl_share_strerror(code: CURLSHcode): PAnsiChar;  cdecl; external;
   {$ifdef LIBCURLMULTI}
   /// add an easy handle to a multi session
   function curl_multi_add_handle(mcurl: TCurlMulti; curl: TCurl): TCurlMultiCode; cdecl; external;
@@ -615,10 +685,11 @@ procedure LibCurlInitialize(engines: TCurlGlobalInit; const dllname: TFileName);
 var P: PPointer;
     api: integer;
     h: {$ifdef FPC}TLibHandle{$else}THandle{$endif FPC};
-const NAMES: array[0..{$ifdef LIBCURLMULTI}26{$else}12{$endif}] of string = (
+const NAMES: array[0..{$ifdef LIBCURLMULTI}30{$else}16{$endif}] of string = (
   'global_init','global_cleanup','version_info',
   'easy_init','easy_setopt','easy_perform','easy_cleanup','easy_getinfo',
-  'easy_duphandle','easy_reset','easy_strerror','slist_append','slist_free_all'
+  'easy_duphandle','easy_reset','easy_strerror','slist_append','slist_free_all',
+  'share_init', 'share_cleanup','share_setopt', 'share_strerror'
   {$ifdef LIBCURLMULTI},
   'multi_add_handle','multi_assign','multi_cleanup','multi_fdset',
   'multi_info_read','multi_init','multi_perform','multi_remove_handle',
@@ -644,6 +715,10 @@ begin
     curl.easy_strerror := @curl_easy_strerror;
     curl.slist_append := @curl_slist_append;
     curl.slist_free_all := @curl_slist_free_all;
+    curl.share_init := @curl_share_init;
+    curl.share_cleanup := @curl_share_cleanup;
+    curl.share_setopt := @curl_share_setopt;
+    curl.strerror := @curl_share_strerror;
     {$ifdef LIBCURLMULTI}
     curl.multi_add_handle := @curl_multi_add_handle;
     curl.multi_assign := @curl_multi_assign;
@@ -700,6 +775,7 @@ begin
         inc(P);
       end;
       curl.Module := h;
+      curl.globalShare := nil;
     except
       on E: Exception do begin
         if h<>0 then
@@ -721,6 +797,54 @@ begin
   end;
 end;
 
+procedure curlShareLock(handle: TCurl; data: curl_lock_data;
+  locktype: curl_lock_access; userptr: pointer); cdecl;
+begin
+  EnterCriticalSection(curl.share_cs[Ord(data)]);
+end;
+
+procedure curlShareUnLock(handle: TCurl; data: curl_lock_data;
+  userptr: pointer); cdecl;
+begin
+  LeaveCriticalSection(curl.share_cs[Ord(data)]);
+end;
+
+function CurlEnableGlobalShare: boolean;
+var
+  i: PtrInt;
+begin
+  Result := false;
+  if not CurlIsAvailable then
+    exit;
+
+  curl.globalShare := curl.share_init;
+  if curl.globalShare = nil then
+    exit; // something went wrong (out of memory, etc.) and therefore the share object was not created
+
+  for i := 0 to Ord(CURL_LOCK_DATA_PSL) do
+    InitializeCriticalSection(curl.share_cs[i]);
+
+  curl.share_setopt(curl.globalShare, CURLSHOPT_LOCKFUNC, @curlShareLock);
+  curl.share_setopt(curl.globalShare, CURLSHOPT_UNLOCKFUNC, @curlShareUnLock);
+  curl.share_setopt(curl.globalShare, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+  curl.share_setopt(curl.globalShare, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+  curl.share_setopt(curl.globalShare, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+  Result := true;
+end;
+
+function CurlDisableGlbalShare: CURLSHcode;
+var
+  i: PtrInt;
+begin
+  Result := CURLSHE_OK;
+  if curl.globalShare = nil then
+    exit;
+  Result := curl.share_cleanup(curl.globalShare);
+  if (Result = CURLSHE_OK) then
+    curl.globalShare := nil;
+  for i := 0 to Ord(CURL_LOCK_DATA_PSL) do
+    DeleteCriticalSection(curl.share_cs[i]);
+end;
 
 initialization
   {$ifdef LIBCURLSTATIC}
@@ -729,10 +853,13 @@ initialization
 
 finalization
   {$ifdef LIBCURLSTATIC}
-  if curl_static_initialized then
+  if curl_static_initialized then begin
+    CurlDisableGlbalShare;
     curl.global_cleanup;
+  end;
   {$else}
   if PtrInt(curl.Module)>0 then begin
+    CurlDisableGlbalShare;
     curl.global_cleanup;
     FreeLibrary(curl.Module);
   end;


### PR DESCRIPTION
If enabled using CurlEnableGlobalShare, then TCurlHTTP will share DNS cache, TLS session cache and connection cache between all requests.
Thread safe.
Performance penalty is ~0