### PR TITLE
fix: it brings ftGuid as string

### DIFF
--- a/SynVirtualDataSet.pas
+++ b/SynVirtualDataSet.pas
@@ -779,7 +779,7 @@ begin
           W.AddDateTime(AsDateTime);
           W.Add('"');
         end;
-        ftString, ftFixedChar, ftMemo: begin
+        ftString, ftFixedChar, ftMemo, ftGuid: begin
           W.Add('"');
           W.AddAnsiString({$ifdef UNICODE}AsAnsiString{$else}AsString{$endif},
             twJSONEscape);


### PR DESCRIPTION
I have a system that uses GUID fields a lot, and DataSetToJSON() always returns "null" on these fields.
This PR fix the translation from DataSet to JSON.