### PR TITLE
fix scaling of emf images in pdf files

### DIFF
--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -10116,10 +10116,7 @@ begin
       end;
     end;
     // use transformation
-    if Custom <> nil then
-      ScaleXForm := Custom^
-    else
-      ScaleXForm := WorldTransform;
+    ScaleXForm := WorldTransform;
     if (ScaleXForm.eM11 > 0) and
        (ScaleXForm.eM22 > 0) and
        (ScaleXForm.eM12 = 0) and


### PR DESCRIPTION
"Custom" has already been used to modify the world matrix, see above.
Use the result and not the modifier for scaling.

The test from #42 still works with this fix too.

Fixes: eefbbdb5 "rotated text SynPdf drawing"

ping @jonjbar