### PR TITLE
SynZip: fix AddFromZip in case source entry is not compressed (stored)

### DIFF
--- a/SynZip.pas
+++ b/SynZip.pas
@@ -943,8 +943,12 @@ begin
   if Count>=length(Entry) then
     SetLength(Entry,length(Entry)+20);
   with Entry[Count] do begin
-    fhr.fileInfo := ZipEntry.infoLocal^;
-    InternalAdd(ZipEntry.zipName,ZipEntry.data,fhr.fileInfo.zzipSize);
+    if ZipEntry.infoLocal.zzipMethod = 0 then // STORED
+      AddStored(ZipEntry.zipName, ZipEntry.data, ZipEntry.infoLocal.zzipSize, ZipEntry.infoLocal.zlastMod)
+    else begin // compressed
+      fhr.fileInfo := ZipEntry.infoLocal^;
+      InternalAdd(ZipEntry.zipName,ZipEntry.data,fhr.fileInfo.zzipSize);
+    end;
   end;
 end;
 


### PR DESCRIPTION
In case source ZIP entry is STORED (not compressed) AddFromZip produce invalid zip file
```
# unzip addFromZipOrigWithErr.zip
extracting: fileUtf8.txt             bad CRC 16223681  (should be 17103e82)
error: invalid zip file with overlapped components (possible zip bomb)
```
This fix such a case.

In the attachment:
 - origin.zip - a source zip with one STORED file
 - addFromZipOrigWithErr.zip - result of AddFromZip without fix
 - addFromZipFixed.zip - result of AddFromZip with fix
