### PR TITLE
force OS in Zip header to be Unix

### DIFF
--- a/SynZip.pas
+++ b/SynZip.pas
@@ -390,7 +390,7 @@ type
   TFileHeader = {$ifdef USERECORDWITHMETHODS}record
     {$else}object{$endif}
     signature     : dword;           // $02014b50 PK#1#2
-    madeBy        : word;            // $14
+    madeBy        : word;            // $314 where $03 - Unix (all clients in this case read UTF8 file names corectly); $14 - version;
     fileInfo      : TFileInfo;
     commentLen    : word;            // 0
     firstDiskNo   : word;            // 0
@@ -865,7 +865,7 @@ begin
   with Entry[Count] do begin
     fHr.signature := ENTRY_SIGNATURE_INC; // +1 to avoid finding it in the exe
     dec(fHr.signature);
-    fHr.madeBy := $14;
+    fHr.madeBy := $314; // $03 - Unix (all clients in this case read UTF8 file names corectly); $14 - version;
     fHr.fileInfo.neededVersion := $14;
     result := InternalWritePosition;
     fHr.localHeadOff := result-fAppendOffset;


### PR DESCRIPTION
 - in this case all zip clients correctly recognize Unicode file names. For 0 (DOS) - most GUI clients ignore UTF8 flag