### PR TITLE
Bug in SecDecrypt

### DIFF
--- a/SQLite3/mORMot.pas
+++ b/SQLite3/mORMot.pas
@@ -52866,8 +52866,10 @@ begin
       // 1st call will return data, 2nd call SessionKey
       result := ClientGetSessionKey(Sender,User,['UserName','','data',BinToBase64(OutData)]);
     until Sender.fSessionData='';
-    if result<>'' then
-      result := SecDecrypt(SecCtx,Base64ToBin(result));
+    if result<>'' then begin
+      OutData := Base64ToBin(result);
+      result := SecDecrypt(SecCtx,OutData);
+    end;
   finally
     FreeSecContext(SecCtx);
   end;

--- a/SynSSPI.pas
+++ b/SynSSPI.pas
@@ -318,8 +318,9 @@ function SecEncrypt(var aSecContext: TSecContext; const aPlain: TSSPIBuffer): TS
 // - aSecContext must be set e.g. from previous success call to ServerSSPIAuth
 // or ClientSSPIAuth
 // - aEncrypted contains data that must be decrypted
+// - warning: aEncrypted is modified in-place during the process
 // - returns decrypted message
-function SecDecrypt(var aSecContext: TSecContext; const aEncrypted: TSSPIBuffer): TSSPIBuffer;
+function SecDecrypt(var aSecContext: TSecContext; var aEncrypted: TSSPIBuffer): TSSPIBuffer;
 
 
 type
@@ -508,7 +509,7 @@ begin
   Move(PByte(InBuf[2].pvBuffer)^, BufPtr^, InBuf[2].cbBuffer);
 end;
 
-function SecDecrypt(var aSecContext: TSecContext; const aEncrypted: TSSPIBuffer): TSSPIBuffer;
+function SecDecrypt(var aSecContext: TSecContext; var aEncrypted: TSSPIBuffer): TSSPIBuffer;
 var EncLen, SigLen: Cardinal;
     BufPtr: PByte;
     InBuf: array [0..1] of TSecBuffer;
@@ -543,7 +544,6 @@ begin
     raise ESynSSPI.CreateLastOSError(aSecContext);
 
   SetString(Result, PAnsiChar(InBuf[1].pvBuffer), InBuf[1].cbBuffer);
-  FreeContextBuffer(InBuf[1].pvBuffer);
 end;
 
 


### PR DESCRIPTION
There is a bug in SecDecrypt, as reported in forum thread:
https://synopse.info/forum/viewtopic.php?pid=36311

Decryption is done in-place, so call to FreeContextBuffer is wrong.
