### PR TITLE
Fix incorrect stroke color bug in SynPDF

### DIFF
--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -10614,6 +10614,7 @@ begin
     if WithClip then begin
       Canvas.GRestore;
       fFillColor := -1; // force set drawing color
+      fStrokeColor := -1; // Ensure stroke color is reset after a GRestore
     end;
     if not Canvas.FNewPath then begin
       if WithClip then


### PR DESCRIPTION
This fix ensures that the stroke colour is reset when GRestore is called.
Before the change
![image](https://user-images.githubusercontent.com/18545429/147024671-81c71cc5-9711-47a5-962a-8746e8fafadc.png)
After the change
![image](https://user-images.githubusercontent.com/18545429/147024706-d11460d9-5952-46c2-9803-e11d97c89ce2.png)

NB: The underline bug is being submitted as a separate PR

This behaviour can be tested with code such as
```
  procedure EmfToPdf(EmfFilename: String; PdfFilename: String);
  const
    C_PDFPPI = 72;
    C_MMperInch = 25.4;
  var
    PDFDocument: TPdfDocument;
    Metafile: TMetafile;
    Scale: Single;
  begin
    Metafile := TMetafile.Create;
    try
      Metafile.LoadFromFile(EmfFilename);
      PDFDocument := TPdfDocument.Create(False, 0, False);
      try
        PDFDocument.DefaultPaperSize := psA4;
        PDFDocument.ScreenLogPixels := C_PDFPPI;
        PDFDocument.AddPage;
        Scale := C_PDFPPI / Trunc((Metafile.Width * 100) / (Metafile.MMWidth / C_MMperInch));
        PDFDocument.Canvas.RenderMetaFile(Metafile, Scale, Scale, 0, 0, tpSetTextJustification, 99, 101, tcAlwaysClip);
        PDFDocument.SaveToFile(PdfFilename);
      finally
        FreeAndNil(PDFDocument);
      end;
    finally
      FreeAndNil(Metafile);
    end;
  end;
```
And using an EMF such as the one in this zip:
[BugsEMF.zip](https://github.com/synopse/mORMot/files/7759527/BugsEMF.zip)

