### PR TITLE
Fix text bugs in SynPDF

### DIFF
--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -10421,7 +10421,7 @@ begin
     if AUseDX then begin
       DX := pointer(PtrUInt(@R)+R.emrtext.offDx);
       W := DXTextWidth(DX, R.emrText.nChars);
-      if W<R.rclBounds.Right-R.rclBounds.Left then // offDX=0 or within box
+      if W < Trunc((R.rclBounds.Right-R.rclBounds.Left) / Canvas.FFactorX) then // offDX=0 or within box
         DX := nil;
     end else
       DX := nil;

--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -10350,7 +10350,7 @@ begin
   with DC[nDC] do begin
     tmp := Pen;
     pen.color := font.color;
-    pen.width := aSize / 15 / Canvas.GetWorldFactorX / Canvas.FDevScaleX;
+    pen.width := aSize / 15 / fscaleY;
     pen.style := PS_SOLID;
     pen.null := False;
     NeedPen;
@@ -10607,9 +10607,9 @@ begin
     end;
     // handle underline or strike out styles (direct draw PDF lines on canvas)
     if font.LogFont.lfUnderline<>0 then
-      DrawLine(Posi, aSize / 8 / Canvas.GetWorldFactorX / Canvas.FDevScaleX);
+      DrawLine(Posi, aSize / 8 / fscaleY);
     if font.LogFont.lfStrikeOut<>0 then
-      DrawLine(Posi, - aSize / 3 / Canvas.GetWorldFactorX / Canvas.FDevScaleX);
+      DrawLine(Posi, - aSize / 4 / fscaleY);
     // end any pending clipped TextRect() region
     if WithClip then begin
       Canvas.GRestore;


### PR DESCRIPTION
These changes fix some bugs in SynPDF:
The first being where text is not respecting the bounding rectangle correctly, and secondly where the strikethroughs and underlines are not drawn correctly, with respect to document scaling.
Before the changes
![image](https://user-images.githubusercontent.com/18545429/147025493-ea1f4080-a204-49cb-895e-da069c54369f.png)
After the changes
![image](https://user-images.githubusercontent.com/18545429/147025502-f3e3bb53-1cd9-45ea-a216-c90181ee4d23.png)

This behaviour can be tested with code such as
```
  procedure EmfToPdf(EmfFilename: String; PdfFilename: String);
  const
    C_PDFPPI = 72;
    C_MMperInch = 25.4;
  var
    PDFDocument: TPdfDocument;
    Metafile: TMetafile;
    Scale: Single;
  begin
    Metafile := TMetafile.Create;
    try
      Metafile.LoadFromFile(EmfFilename);
      PDFDocument := TPdfDocument.Create(False, 0, False);
      try
        PDFDocument.DefaultPaperSize := psA4;
        PDFDocument.ScreenLogPixels := C_PDFPPI;
        PDFDocument.AddPage;
        Scale := C_PDFPPI / Trunc((Metafile.Width * 100) / (Metafile.MMWidth / C_MMperInch));
        PDFDocument.Canvas.RenderMetaFile(Metafile, Scale, Scale, 0, 0, tpSetTextJustification, 99, 101, tcAlwaysClip);
        PDFDocument.SaveToFile(PdfFilename);
      finally
        FreeAndNil(PDFDocument);
      end;
    finally
      FreeAndNil(Metafile);
    end;
  end;
```
And using an EMF such as the one in this zip:
[BugsEMF.zip](https://github.com/synopse/mORMot/files/7759527/BugsEMF.zip)