### PR TITLE
Fix fill region bugs in SynPDF

### DIFF
--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -8954,6 +8954,12 @@ type
     width: Single;
   end;
 
+  TPdfEnumStateBrush = record
+    null: boolean;
+    color: integer;
+    style: integer;
+  end;
+
   /// a state of the EMF enumeration engine, for the PDF canvas
   // - used also for the SaveDC/RestoreDC stack
   TPdfEnumState = record
@@ -8973,11 +8979,7 @@ type
     // current selected pen
     pen: TPdfEnumStatePen;
     // current selected brush
-    brush: record
-      null: boolean;
-      color: integer;
-      style: integer;
-    end;
+    brush: TPdfEnumStateBrush;
     // current selected font
     font: record
       color: integer;
@@ -9069,6 +9071,7 @@ var i: integer;
     polytypes: PByteArray;
     RegionData: PRgnData;
     PtrRect: PRect;
+    CurrentBrush: TPdfEnumStateBrush;
 begin
   result := true;
   with E.DC[E.nDC] do
@@ -9235,6 +9238,7 @@ begin
   end;
   {$endif USE_ARC}
   EMR_FILLRGN: begin
+    MoveFast(E.DC[E.nDC].brush, CurrentBrush, SizeOf(TPdfEnumStateBrush));
     E.SelectObjectFromIndex(PEMRFillRgn(R)^.ihBrush);
     E.NeedBrushAndPen;
     RegionData := PRgnData(@PEMRFillRgn(R)^.RgnData[0]);
@@ -9243,6 +9247,7 @@ begin
       E.FillRectangle(PtrRect^, False);
       Inc(PtrRect);
     end;
+    MoveFast(CurrentBrush, E.DC[E.nDC].brush, SizeOf(TPdfEnumStateBrush));
   end;
   EMR_POLYGON, EMR_POLYLINE, EMR_POLYGON16, EMR_POLYLINE16:
   if not brush.null or not pen.null then begin


### PR DESCRIPTION
These changes fix some bugs in SynPDF relating to filling regions.
- The first commit ensures complex regions are filled using the defined region rather than the bounding rectangle
- The second commit fixes a bug where the current brush is incorrectly changed with filling a region

Before the changes
![image](https://user-images.githubusercontent.com/18545429/147026878-149ab778-f447-46f1-b982-5ee42b4e25b5.png)
After the changes
![image](https://user-images.githubusercontent.com/18545429/147026897-6cb021b8-004a-47a1-8c80-93a99fae85e5.png)

This behaviour can be tested with code such as
```
  procedure EmfToPdf(EmfFilename: String; PdfFilename: String);
  const
    C_PDFPPI = 72;
    C_MMperInch = 25.4;
  var
    PDFDocument: TPdfDocument;
    Metafile: TMetafile;
    Scale: Single;
  begin
    Metafile := TMetafile.Create;
    try
      Metafile.LoadFromFile(EmfFilename);
      PDFDocument := TPdfDocument.Create(False, 0, False);
      try
        PDFDocument.DefaultPaperSize := psA4;
        PDFDocument.ScreenLogPixels := C_PDFPPI;
        PDFDocument.AddPage;
        Scale := C_PDFPPI / Trunc((Metafile.Width * 100) / (Metafile.MMWidth / C_MMperInch));
        PDFDocument.Canvas.RenderMetaFile(Metafile, Scale, Scale, 0, 0, tpSetTextJustification, 99, 101, tcAlwaysClip);
        PDFDocument.SaveToFile(PdfFilename);
      finally
        FreeAndNil(PDFDocument);
      end;
    finally
      FreeAndNil(Metafile);
    end;
  end;
```
And using an EMF such as the one in this zip:
[BugsEMF.zip](https://github.com/synopse/mORMot/files/7759527/BugsEMF.zip)