### PR TITLE
Fix problem with horizontal scaling in SynPDF

### DIFF
--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -10597,14 +10597,6 @@ begin
       end else
         Canvas.ShowText(pointer(tmp));
     Canvas.EndText;
-    case Positioning of
-    tpSetTextJustification:
-      if nspace>0 then
-        Canvas.SetWordSpace(0);
-    tpKerningFromAveragePosition:
-      if hscale<>100 then
-        Canvas.SetHorizontalScaling(100); //reset hor. scaling
-    end;
     // handle underline or strike out styles (direct draw PDF lines on canvas)
     if font.LogFont.lfUnderline<>0 then
       DrawLine(Posi, aSize / 8 / Canvas.GetWorldFactorX / Canvas.FDevScaleX);
@@ -10615,6 +10607,16 @@ begin
       Canvas.GRestore;
       fFillColor := -1; // force set drawing color
     end;
+    
+    case Positioning of
+    tpSetTextJustification:
+      if nspace>0 then
+        Canvas.SetWordSpace(0);
+    tpKerningFromAveragePosition:
+      if hscale<>100 then
+        Canvas.SetHorizontalScaling(100); //reset hor. scaling
+    end;
+    
     if not Canvas.FNewPath then begin
       if WithClip then
         if not DC[nDC].ClipRgnNull then begin


### PR DESCRIPTION
This change fixes a bug in SynPDF where the horizontal scaling is incorrect.
This issue can be found in this ticket from 2014, https://synopse.info/fossil/tktview?name=f1fdab52ce