### PR TITLE
fix: SynBidirSock.pas raise access violation errors when ProcessMask()

### DIFF
--- a/SynBidirSock.pas
+++ b/SynBidirSock.pas
@@ -2894,7 +2894,7 @@ begin
   result := GetBytes(pointer(data),hdr.len32);
   if result then begin
     if hdr.mask<>0 then
-      ProcessMask(pointer(data),hdr.mask,hdr.len32);
+      ProcessMask(@data[1],hdr.mask,hdr.len32);
     len := 0; // prepare upcoming GetHeader
   end;
 end;
@@ -3013,7 +3013,7 @@ begin
       end;
       if fMaskSentFrames<>0 then begin
         hdr.mask := Random32gsl; // https://tools.ietf.org/html/rfc6455#section-10.3
-        ProcessMask(pointer(Frame.payload),hdr.mask,len);
+        ProcessMask(@Frame.payload[1],hdr.mask,len);
         inc(hdrlen,4);
       end;
       tmp.Init(hdrlen+len); // avoid most memory allocations

--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -9299,6 +9299,7 @@ begin
         InCompressAccept := ComputeContentEncoding(fCompress,pointer(InAcceptEncoding));
         Context.fUseSSL := Req^.pSslInfo<>nil;
         Context.fInHeaders := RetrieveHeaders(Req^,fRemoteIPHeaderUpper,RemoteIP);
+        Context.RemoteIP  :=  RemoteIP;
         // compute remote connection ID
         L := length(fRemoteConnIDHeaderUpper);
         if L<>0 then begin


### PR DESCRIPTION
1. run Project31WinHTTPEchoServer.exe
2. execute this test code:
```pascal
var
  Client :  THttpClientWebSockets;
  protocol : TWebSocketProtocol;
  frame: TWebSocketFrame;
begin
  protocol := TWebSocketProtocolChat.Create('meow', 'whatever');
  Client := THttpClientWebSockets.WebSocketsConnect(
      'localhost','8888',protocol, nil, '', 'whatever');
  frame.opcode  :=  focText;
  frame.content :=  [];
  frame.payload :=  'test1234';
  Client.WebSockets.SendFrame(frame); //av error
  Client.free;
end;
```