### PR TITLE
Fix for setting ParenthesisAfter property value in TSynTableStatement…

### DIFF
--- a/SynSelfTests.pas
+++ b/SynSelfTests.pas
@@ -10891,6 +10891,23 @@ begin
   Check((length(Stmt.Select)=2)and(Stmt.Select[1].Field=0)and
     (Props.Fields.List[Stmt.Select[0].Field-1].Name='Data'));
   Check(Stmt.OrderByField=nil);
+  NewStmt('select id from tab where YearOfBirth=1600 and (YearOfDeath<>80 or YearOfDeath is null)');
+  Check(Stmt.TableName='tab');
+  Check(length(Stmt.Where)=3);
+  Check(Props.Fields.List[Stmt.Where[0].Field-1].Name='YearOfBirth');
+  Check(Stmt.Where[0].Operator=opEqualTo);
+  Check(Stmt.Where[0].Value='1600');
+  Check(Props.Fields.List[Stmt.Where[1].Field-1].Name='YearOfDeath');
+  Check(Stmt.Where[1].Operator=opNotEqualTo);
+  Check(Stmt.Where[1].ParenthesisBefore='(');
+  Check(Stmt.Where[1].Value='80');
+  Check(Stmt.Where[2].JoinedOR);
+  Check(Props.Fields.List[Stmt.Where[2].Field-1].Name='YearOfDeath');
+  Check(Stmt.Where[2].Operator=opIsNull);
+  Check(Stmt.Where[2].ParenthesisAfter=')');
+  Check(Stmt.Limit=0);
+  Check(Stmt.Offset=0);
+  Check(Stmt.OrderByField=nil);
   NewStmt('select count(*) from tab');
   Check(Stmt.TableName='tab');
   Check(Stmt.Where=nil);

--- a/SynTable.pas
+++ b/SynTable.pas
@@ -7380,6 +7380,19 @@ begin
   inc(selectCount);
   result := true;
 end;
+procedure GetWhereParenthesisAfter(var Where: TSynTableStatementWhere);
+var B: PUTF8Char;
+begin
+  if (P^=')') and (Where.FunctionName='') then begin
+    B := P;
+    repeat
+      inc(P);
+    until not (P^ in [#1..' ',')']);
+    while P[-1]=' ' do dec(P); // trim right space
+    SetString(Where.ParenthesisAfter,B,P-B);
+    P := GotoNextNotSpace(P);
+  end;
+end;
 function GetWhereValue(var Where: TSynTableStatementWhere): boolean;
 var B: PUTF8Char;
 begin
@@ -7430,15 +7443,7 @@ begin
     inc(P,2); // ignore :(...): parameter
   Where.ValueSQLLen := P-Where.ValueSQL;
   P := GotoNextNotSpace(P);
-  if (P^=')') and (Where.FunctionName='') then begin
-    B := P;
-    repeat
-      inc(P);
-    until not (P^ in [#1..' ',')']);
-    while P[-1]=' ' do dec(P); // trim right space
-    SetString(Where.ParenthesisAfter,B,P-B);
-    P := GotoNextNotSpace(P);
-  end;
+  GetWhereParenthesisAfter(Where);
   result := true;
 end;
 {$ifndef NOVARIANTS}
@@ -7540,6 +7545,7 @@ begin
         inc(P,8);
         result := true; // leave ValueVariant=unassigned
       end;
+      GetWhereParenthesisAfter(Where);
       exit;
     end;
     {$ifndef NOVARIANTS}


### PR DESCRIPTION
… class while parsing SQL with complex condition like:

select field from table where id=? and (column1<>? or column1 is null)

Before correction this query is not correctly parsed in the class TSynTableStatement - closing parenthesis is missing. This causes SQL execution error in my case in Oracle, but probably also in any other database engines.