### PR TITLE
Fix Delphi compiler warning

### DIFF
--- a/SynLog.pas
+++ b/SynLog.pas
@@ -4659,7 +4659,8 @@ end;
 
 procedure TSynLog.LogInternal(Level: TSynLogInfo; const Text: RawUTF8;
   Instance: TObject; TextTruncateAtLength: integer);
-var LastError,L: cardinal;
+var LastError: cardinal;
+    L: integer;
 begin
   if Level=sllLastError then
     LastError := GetLastError else


### PR DESCRIPTION
[dcc32 Warning] SynLog.pas(4685): W1023 Comparing signed and unsigned types - widened both operands

https://github.com/synopse/mORMot/blob/master/SynLog.pas#L4685