### PR TITLE
Fixes for access violations in SynDBExplorer

### DIFF
--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorer.dproj
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorer.dproj
@@ -1,0 +1,186 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{5709B2DA-1B88-4409-A946-0EF5ACAD24B9}</ProjectGuid>
+        <MainSource>SynDBExplorer.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <ProjectName Condition="'$(ProjectName)'==''">SynDBExplorer</ProjectName>
+        <TargetedPlatforms>660481</TargetedPlatforms>
+        <AppType>Application</AppType>
+        <FrameworkType>VCL</FrameworkType>
+        <ProjectVersion>20.1</ProjectVersion>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
+        <Base_iOSDevice64>true</Base_iOSDevice64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Cfg_2)'=='true') or '$(Cfg_2_iOSDevice64)'!=''">
+        <Cfg_2_iOSDevice64>true</Cfg_2_iOSDevice64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Cfg_2)'=='true') or '$(Cfg_2_OSX64)'!=''">
+        <Cfg_2_OSX64>true</Cfg_2_OSX64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSXARM64' and '$(Cfg_2)'=='true') or '$(Cfg_2_OSXARM64)'!=''">
+        <Cfg_2_OSXARM64>true</Cfg_2_OSXARM64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_2)'=='true') or '$(Cfg_2_Win32)'!=''">
+        <Cfg_2_Win32>true</Cfg_2_Win32>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_E>false</DCC_E>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_ImageBase>00400000</DCC_ImageBase>
+        <SanitizedProjectName>SynDBExplorer</SanitizedProjectName>
+        <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;$(DCC_Namespace)</DCC_Namespace>
+        <VerInfo_Locale>1031</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=;CFBundleName=</VerInfo_Keys>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName)</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
+        <Icon_MainIcon>SynDBExplorer_Icon.ico</Icon_MainIcon>
+        <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
+        <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <Icon_MainIcon>SynDBExplorer_Icon.ico</Icon_MainIcon>
+        <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
+        <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_RangeChecking>true</DCC_RangeChecking>
+        <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_iOSDevice64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_OSX64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_OSXARM64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
+        <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="SynDBExplorerMain.pas">
+            <Form>DbExplorerMain</Form>
+        </DCCReference>
+        <DCCReference Include="SynDBExplorerClasses.pas"/>
+        <DCCReference Include="SynDBExplorerFrame.pas">
+            <Form>DBExplorerFrame</Form>
+            <DesignClass>TFrame</DesignClass>
+        </DCCReference>
+        <DCCReference Include="SynDBExplorerQueryBuilder.pas">
+            <Form>DBQueryBuilderForm</Form>
+        </DCCReference>
+        <DCCReference Include="SynDBExplorerExportTables.pas">
+            <Form>DBExportTablesForm</Form>
+        </DCCReference>
+        <DCCReference Include="SynDBExplorerServer.pas">
+            <Form>HTTPServerForm</Form>
+        </DCCReference>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">SynDBExplorer.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="iOSDevice64">True</Platform>
+                <Platform value="iOSSimARM64">True</Platform>
+                <Platform value="OSX64">True</Platform>
+                <Platform value="OSXARM64">True</Platform>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.dfm
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.dfm
@@ -1,6 +1,7 @@
 object DBExportTablesForm: TDBExportTablesForm
   Left = 387
   Top = 248
+  BorderStyle = bsDialog
   Caption = ' SynDB Explorer - Export Tables'
   ClientHeight = 471
   ClientWidth = 393

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.dfm
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.dfm
@@ -1,7 +1,6 @@
 object DBExportTablesForm: TDBExportTablesForm
   Left = 387
   Top = 248
-  BorderStyle = bsDialog
   Caption = ' SynDB Explorer - Export Tables'
   ClientHeight = 471
   ClientWidth = 393
@@ -11,12 +10,10 @@ object DBExportTablesForm: TDBExportTablesForm
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  OldCreateOrder = False
   Position = poMainFormCenter
   DesignSize = (
     393
     471)
-  PixelsPerInch = 96
   TextHeight = 13
   object BtnExport: TButton
     Left = 24

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.pas
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.pas
@@ -32,11 +32,11 @@ implementation
 
 {$R *.dfm}
 
-
 resourcestring
   sTableExportWhereHint = 'e.g. "ID>1000" or "RowNum<=500"';
 
-  { TDBExportTablesForm }
+  
+{ TDBExportTablesForm }
 
 class function TDBExportTablesForm.ExportTables(aTableNames: TStrings;
   aProps: TSQLDBConnectionProperties; const aDestFileName: TFileName): integer;
@@ -127,14 +127,14 @@ var T: TStringList;
     i: integer;
 begin
   result := 0;
-  if (aListBox = nil) or (aListBox.SelCount = 0) then
+  if (aListBox=nil) or (aListBox.SelCount=0) then
     exit;
   T := TStringList.Create;
   try
-    for i := 0 to aListBox.Count - 1 do
+    for i := 0 to aListBox.Count-1 do
       if aListBox.Selected[i] then
         T.Add(aListBox.Items[i]);
-    result := ExportTables(T, aProps, aDestFileName);
+    result := ExportTables(T,aProps,aDestFileName);
   finally
     T.Free;
   end;
@@ -147,23 +147,23 @@ begin
   if Value=nil then
     n := 0 else
     n := Value.Count;
-  SetLength(fEdits, n);
+  SetLength(fEdits,n);
   max := Screen.Height;
   if n*32+132>max then
     h := 24 else
     h := 32;
   x := 160;
-  n := n * h + 24;
-  if n + 148 > max then
-    n := max - 164;
+  n := n*h+24;
+  if n+148>max then
+    n := max-164;
   GroupWhere.Height := n;
-  ClientHeight := n + 132;
+  ClientHeight := n+132;
   y := 24;
   for i := 0 to high(fEdits) do begin
     E := TLabeledEdit.Create(self);
     E.Parent := GroupWhere;
     E.LabelPosition := lpLeft;
-    E.SetBounds(x, y, 180, 22);
+    E.SetBounds(x,y,180,22);
     E.EditLabel.Caption := Value[i];
     E.ShowHint := true;
     E.Hint := sTableExportWhereHint;
@@ -174,7 +174,7 @@ begin
       y := 24;
       inc(x,340);
       Width := 740;
-      end;
+    end;
   end;
 end;
 

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.pas
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerExportTables.pas
@@ -32,11 +32,11 @@ implementation
 
 {$R *.dfm}
 
+
 resourcestring
   sTableExportWhereHint = 'e.g. "ID>1000" or "RowNum<=500"';
 
-  
-{ TDBExportTablesForm }
+  { TDBExportTablesForm }
 
 class function TDBExportTablesForm.ExportTables(aTableNames: TStrings;
   aProps: TSQLDBConnectionProperties; const aDestFileName: TFileName): integer;
@@ -127,14 +127,14 @@ var T: TStringList;
     i: integer;
 begin
   result := 0;
-  if (aListBox=nil) or (aListBox.SelCount=0) then
+  if (aListBox = nil) or (aListBox.SelCount = 0) then
     exit;
   T := TStringList.Create;
   try
-    for i := 0 to aListBox.Count-1 do
+    for i := 0 to aListBox.Count - 1 do
       if aListBox.Selected[i] then
         T.Add(aListBox.Items[i]);
-    result := ExportTables(T,aProps,aDestFileName);
+    result := ExportTables(T, aProps, aDestFileName);
   finally
     T.Free;
   end;
@@ -147,33 +147,34 @@ begin
   if Value=nil then
     n := 0 else
     n := Value.Count;
-  SetLength(fEdits,n);
+  SetLength(fEdits, n);
   max := Screen.Height;
   if n*32+132>max then
     h := 24 else
     h := 32;
   x := 160;
-  n := n*h+24;
-  if n+148>max then
-    n := max-164;
+  n := n * h + 24;
+  if n + 148 > max then
+    n := max - 164;
   GroupWhere.Height := n;
-  ClientHeight := n+132;
+  ClientHeight := n + 132;
   y := 24;
   for i := 0 to high(fEdits) do begin
     E := TLabeledEdit.Create(self);
     E.Parent := GroupWhere;
     E.LabelPosition := lpLeft;
-    E.SetBounds(x,y,180,22);
+    E.SetBounds(x, y, 180, 22);
     E.EditLabel.Caption := Value[i];
     E.ShowHint := true;
     E.Hint := sTableExportWhereHint;
+    fEdits[i] := E;
     inc(y,h);
     if (h=24) and (y>=n-24) and (i<>high(fEdits)) then
     if x<>160 then break else begin
       y := 24;
       inc(x,340);
       Width := 740;
-    end;
+      end;
   end;
 end;
 

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerQueryBuilder.dfm
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerQueryBuilder.dfm
@@ -1,7 +1,6 @@
 object DBQueryBuilderForm: TDBQueryBuilderForm
   Left = 1019
   Top = 265
-  BorderStyle = bsSingle
   Caption = ' SynDB Explorer - Query Builder'
   ClientHeight = 374
   ClientWidth = 799
@@ -11,12 +10,10 @@ object DBQueryBuilderForm: TDBQueryBuilderForm
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  OldCreateOrder = False
   Position = poMainFormCenter
   DesignSize = (
     799
     374)
-  PixelsPerInch = 96
   TextHeight = 13
   object GroupJoin: TGroupBox
     Left = 344
@@ -52,7 +49,7 @@ object DBQueryBuilderForm: TDBQueryBuilderForm
       Width = 177
       Height = 160
       Anchors = [akLeft, akTop, akBottom]
-      ItemHeight = 13
+      ItemHeight = 17
       TabOrder = 1
       OnClick = FieldsColumnClick
     end

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerQueryBuilder.pas
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerQueryBuilder.pas
@@ -14,7 +14,7 @@ type
     NameWithSchema: RawUTF8;
     Fields: TSQLDBColumnDefineDynArray;
     FieldsDefinition,
-    FieldsAlias: TRawUTF8DynArray;
+      FieldsAlias: TRawUTF8DynArray;
     SelectedAll: boolean;
     Selected: set of byte;
     function FieldAlias(FieldIndex: integer): RawUTF8;
@@ -23,14 +23,17 @@ type
     function AsTSQLRecordType(Props: TSQLDBConnectionProperties): RawUTF8;
     function FromIniSection(P: PUTF8Char): PUTF8Char;
   end;
+
   TDBQueryJoin = record
     SourceTable: integer;
     SourceField: integer;
     DestTable: integer;
     DestField: integer;
   end;
+
   TDBQueryTableDynArray = array of TDBQueryTable;
-  TDBQueryJoinDynArray = array of TDBQueryJoin;
+  TDBQueryJoinDynArray  = array of TDBQueryJoin;
+
   TDBQueryObject = object
     Name: string;
     Tables: TDBQueryTableDynArray;
@@ -38,11 +41,12 @@ type
     procedure InitJOIN(Size: integer);
     function ComputeSQLSelect: RawUTF8;
     function AsIniSection: string;
-    function FromIniSection(P: PUTF8Char): Boolean; overload;
-    function FromIniSection(const IniContent: RawUTF8): Boolean; overload;
+    function FromIniSection(P: PUTF8Char): boolean; overload;
+    function FromIniSection(const IniContent: RawUTF8): boolean; overload;
   end;
+
   PDBQueryTable = ^TDBQueryTable;
-  
+
   TDBQueryBuilderForm = class(TForm)
     GroupJoin: TGroupBox;
     GroupFields: TGroupBox;
@@ -62,9 +66,9 @@ type
     procedure BtnToObjectClick(Sender: TObject);
     procedure MenuToOneTSQLRecordClick(Sender: TObject);
   private
-    fProps: TSQLDBConnectionProperties;
-    fObject: TDBQueryObject;
-    fJOINUI: array of record
+    fProps       : TSQLDBConnectionProperties;
+    fObject      : TDBQueryObject;
+    fJOINUI      : array of record
       SourceTable: TComboBox;
       SourceField: TComboBox;
       DestTable: TComboBox;
@@ -85,7 +89,6 @@ type
 resourcestring
   sMissingJOIN = 'Missing JOIN';
 
-
 implementation
 
 {$R *.dfm}
@@ -95,11 +98,11 @@ implementation
 function TDBQueryTable.AsIniRow: RawUTF8;
 var f: integer;
 begin
-  result := FormatUTF8('%,%,%,',[Name,length(Fields),SelectedAll]);
+  result := FormatUTF8('%,%,%,', [Name, length(Fields), SelectedAll]);
   for f := 0 to high(Fields) do
-  with Fields[f] do
-    result := FormatUTF8('%%,%,%,%,',
-      [result,ColumnName,Ord(ColumnType),FieldAlias(f),f in Selected]);
+    with Fields[f] do
+      result := FormatUTF8('%%,%,%,%,',
+        [result, ColumnName, Ord(ColumnType), FieldAlias(f), f in Selected]);
 end;
 
 function TDBQueryTable.AsTSQLRecordType(Props: TSQLDBConnectionProperties): RawUTF8;
@@ -107,7 +110,7 @@ var f, RowIDIndex: integer;
     IdField: TSQLDBColumnCreate;
     def: RawUTF8;
 begin
-  RowIDIndex := -1;
+  RowIDIndex := - 1;
   for f := 0 to high(Fields) do
   with Fields[f] do begin
     if IsRowID(pointer(ColumnName)) then begin
@@ -138,11 +141,11 @@ begin
     IdField.Name := 'ID';
     IdField.DBType := ftUnknown;
     IdField.PrimaryKey := true;
-    result := FormatUTF8('%  // - note that the ORM will add one missing ID field via:'#13#10+
-      '  // $ %'#13#10,[result,Props.SQLAddColumn(NameWithSchema,IdField)]);
+    result := FormatUTF8('%  // - note that the ORM will add one missing ID field via:'#13#10 +
+      '  // $ %'#13#10, [result, Props.SQLAddColumn(NameWithSchema, IdField)]);
   end;
   result := FormatUTF8('%  TSQL% = class(TSQLRecord)'#13#10'  protected'#13#10'%  end;',
-    [result,NameWithoutSchema,def]);
+    [result, NameWithoutSchema, def]);
 end;
 
 function TDBQueryTable.FieldAlias(FieldIndex: integer): RawUTF8;
@@ -176,7 +179,7 @@ begin
   SelectedAll := GetNextItemCardinal(result)=1;
   if result=nil then exit;
   Selected := [];
-  SetLength(FieldsAlias,length(Fields));
+  SetLength(FieldsAlias, length(Fields));
   for i := 0 to high(Fields) do
   with Fields[i] do begin
     ColumnName := GetNextItem(result);
@@ -187,7 +190,6 @@ begin
   end;
 end;
 
-
 { TDBQueryObject }
 
 function TDBQueryObject.AsIniSection: string;
@@ -195,13 +197,13 @@ var ini: RawUTF8;
     t: integer;
 begin
   ini := FormatUTF8('[%]'#13#10'TableCount=%'#13#10,
-    [Name,length(Tables)]);
+    [Name, length(Tables)]);
   for t := 0 to high(Tables) do
-    ini := FormatUTF8('%Table%=%'#13#10,[ini,t,Tables[t].AsIniRow]);
+    ini := FormatUTF8('%Table%=%'#13#10, [ini, t, Tables[t].AsIniRow]);
   for t := 0 to high(JOIN) do
     with JOIN[t] do
       ini := FormatUTF8('%Join%=%,%,%,%'#13#10,
-        [ini,t,SourceTable,SourceField,DestTable,DestField]);
+        [ini, t, SourceTable, SourceField, DestTable, DestField]);
   result := UTF8ToString(ini);
 end;
 
@@ -295,11 +297,11 @@ begin
         SourceTable := GetNextItemCardinal(P);
         SourceField := GetNextItemCardinal(P);
         DestTable := GetNextItemCardinal(P);
-        DestField := GetNextItemCardinal(P,#13);
+        DestField := GetNextItemCardinal(P, #13);
       end;
     end;
   end;
-  result := True;
+  result := true;
 end;
 
 function TDBQueryObject.FromIniSection(const IniContent: RawUTF8): Boolean;
@@ -311,10 +313,12 @@ end;
 
 procedure TDBQueryObject.InitJOIN(Size: integer);
 begin
-  SetLength(JOIN,Size);
-  fillchar(JOIN[0],Size*sizeof(JOIN[0]),255); // fill all to -1
+  if Size > 0 then
+  begin
+    SetLength(JOIN, Size);
+    fillchar(JOIN[0], Size * sizeof(JOIN[0]), 255); // fill all to -1
+  end;
 end;
-
 
 { TDBQueryBuilderForm }
 
@@ -322,21 +326,21 @@ class function TDBQueryBuilderForm.BuildQuery(aTableNames: TStrings;
   aProps: TSQLDBConnectionProperties; out SQL: string): integer;
 begin
   result := mrCancel;
-  if (aProps<>nil) and (aTableNames<>nil) then
-  with TDBQueryBuilderForm.Create(Application) do
-  try
-    Props := aProps;
-    SetTableNames(aTableNames);
-    result := ShowModal;
-    case result of
-    mrOk,mrYes:
-      SQL := MemoSQL.Text;
-    mrRetry:
-      SQL := fObject.AsIniSection; 
-    end;
-  finally
-    Free;
-  end;
+  if (aProps <> nil) and (aTableNames <> nil) then
+    with TDBQueryBuilderForm.Create(Application) do
+      try
+        Props := aProps;
+        SetTableNames(aTableNames);
+        result := ShowModal;
+        case result of
+          mrOk, mrYes:
+            SQL := MemoSQL.Text;
+          mrRetry:
+            SQL := fObject.AsIniSection;
+        end;
+      finally
+        Free;
+      end;
 end;
 
 class function TDBQueryBuilderForm.BuildQuery(aListBox: TListBox;
@@ -345,16 +349,16 @@ var T: TStringList;
     i: integer;
 begin
   result := mrCancel;
-  if (aListBox=nil) or (aListBox.SelCount=0) then
+  if (aListBox = nil) or (aListBox.SelCount = 0) then
     exit;
-  T := TStringList.Create;
+  t := TStringList.Create;
   try
-    for i := 0 to aListBox.Count-1 do
+    for i := 0 to aListBox.Count - 1 do
       if aListBox.Selected[i] then
-        T.Add(aListBox.Items[i]);
-    result := BuildQuery(T,aProps,SQL);
+        t.Add(aListBox.Items[i]);
+    result := BuildQuery(t, aProps, SQL);
   finally
-    T.Free;
+    t.Free;
   end;
 end;
 
@@ -365,7 +369,7 @@ var t,j,f,k,Y: Integer;
   begin
     result := TComboBox.Create(self);
     result.Parent := GroupJoin;
-    result.SetBounds(X,Y,100,20);
+    result.SetBounds(X, Y, 100, 20);
     result.Style := csDropDownList;
     result.Font.Size := 7;
     if Table>=0 then begin
@@ -375,12 +379,13 @@ var t,j,f,k,Y: Integer;
     end else
       result.OnClick := ComputeSQL;
   end;
+
 begin
   FieldsTable.Clear;
   Screen.Cursor := crHourGlass;
   try
     // fill fObject.Tables[]
-    SetLength(fObject.Tables,Value.Count);
+    SetLength(fObject.Tables, Value.Count);
     for t := 0 to high(fObject.Tables) do
     with fObject.Tables[t] do begin
       Name := Value[t];
@@ -394,7 +399,7 @@ begin
       FieldsTable.Items.Add(Name);
     end;
     // create JOIN controls on form
-    SetLength(fJOINUI,length(fObject.Tables)-1);
+    SetLength(fJOINUI, length(fObject.Tables) - 1);
     Y := 20;
     for t := 0 to high(fJOINUI) do
     with fJOINUI[t] do begin
@@ -464,12 +469,12 @@ var i: integer;
     T: PDBQueryTable;
 begin
   FieldsColumn.Clear;
-  T := FieldsTableCurrent;
-  if T=nil then
+  t := FieldsTableCurrent;
+  if t = nil then
     exit;
-  for i := 0 to High(T^.FieldsDefinition) do
-    FieldsColumn.Items.Add(Ansi7ToString(T^.FieldsDefinition[i]));
-  FieldsAll.Checked := T^.SelectedAll;
+  for i := 0 to High(t^.FieldsDefinition) do
+    FieldsColumn.Items.Add(Ansi7ToString(t^.FieldsDefinition[i]));
+  FieldsAll.Checked := t^.SelectedAll;
   FieldsAllClick(nil);
 end;
 
@@ -478,12 +483,12 @@ var T: PDBQueryTable;
     i: integer;
 begin
   FieldsColumn.Enabled := not FieldsAll.Checked;
-  T := FieldsTableCurrent;
-  if T=nil then
+  t := FieldsTableCurrent;
+  if t = nil then
     exit;
-  T^.SelectedAll := FieldsAll.Checked;
-  for i := 0 to High(T^.Fields) do
-    FieldsColumn.Checked[i] := i in T^.Selected;
+  t^.SelectedAll := FieldsAll.Checked;
+  for i := 0 to High(t^.Fields) do
+    FieldsColumn.Checked[i] := i in t^.Selected;
   ComputeSQL(nil);
 end;
 
@@ -500,13 +505,13 @@ procedure TDBQueryBuilderForm.FieldsColumnClick(Sender: TObject);
 var T: PDBQueryTable;
     i: integer;
 begin
-  T := FieldsTableCurrent;
-  if T=nil then
+  t := FieldsTableCurrent;
+  if t = nil then
     exit;
-  FillChar(T^.Selected,sizeof(T^.Selected),0);
-  for i := 0 to High(T^.Fields) do
+  fillchar(t^.Selected, sizeof(t^.Selected), 0);
+  for i := 0 to High(t^.Fields) do
     if FieldsColumn.Checked[i] then
-      Include(T^.Selected,i);
+      include(t^.Selected, i);
   ComputeSQL(nil);
 end;
 
@@ -531,17 +536,16 @@ begin
   Field := TComboBox(Table.Tag);
   Field.Items.Clear;
   t := Table.ItemIndex;
-  if t>=0 then
+  if t >= 0 then
     with fObject.Tables[t] do
-    for f := 0 to high(Fields) do
-      Field.Items.Add(Ansi7ToString(Fields[f].ColumnName));
+      for f := 0 to high(Fields) do
+        Field.Items.Add(Ansi7ToString(Fields[f].ColumnName));
 end;
-
 
 procedure TDBQueryBuilderForm.BtnToObjectClick(Sender: TObject);
 begin
-  with ClientToScreen(Point(BtnToObject.Left,BtnToObject.Top+BtnToObject.Height)) do
-      BtnToObjectMenu.Popup(X,Y);
+  with ClientToScreen(Point(BtnToObject.Left, BtnToObject.Top + BtnToObject.Height)) do
+    BtnToObjectMenu.Popup(X, Y);
 end;
 
 procedure TDBQueryBuilderForm.MenuToOneTSQLRecordClick(Sender: TObject);
@@ -551,7 +555,7 @@ var s: RawUTF8;
 begin
   s := 'type'#13#10;
   for i := 0 to high(fObject.Tables) do
-    s := s+fObject.Tables[i].AsTSQLRecordType(Props)+#13#10#13#10;
+    s := s + fObject.Tables[i].AsTSQLRecordType(Props) + #13#10#13#10;
   txt := UTF8ToString(s);
   MemoSQL.Text := txt;
   Clipboard.AsText := txt;

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerServer.dfm
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerServer.dfm
@@ -11,9 +11,7 @@ object HTTPServerForm: THTTPServerForm
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  OldCreateOrder = False
   OnDestroy = FormDestroy
-  PixelsPerInch = 96
   TextHeight = 13
   object lbledtPort: TLabeledEdit
     Left = 40

--- a/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerServer.dfm
+++ b/SQLite3/Samples/12 - SynDB Explorer/SynDBExplorerServer.dfm
@@ -11,7 +11,9 @@ object HTTPServerForm: THTTPServerForm
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
+  OldCreateOrder = False
   OnDestroy = FormDestroy
+  PixelsPerInch = 96
   TextHeight = 13
   object lbledtPort: TLabeledEdit
     Left = 40


### PR DESCRIPTION
Fixed:
- Access violations when trying to Export a DB table or when trying to Build a query. Fixed in SynDBExplorerExportTables.pas and SynDBExplorerQueryBuilder.pas
Changed:
- Forms sizeable: SynDBExplorerExportTables.dfm, SynDBExplorerQueryBuilder.dfm
Added: 
- Delphi project file for Delphi 12
