### PR TITLE
WebSocket Add URL Parameter Support

### DIFF
--- a/SynBidirSock.pas
+++ b/SynBidirSock.pas
@@ -2300,17 +2300,19 @@ end;
 function TWebSocketProtocolList.CloneByName(
   const aProtocolName, aClientURI: RawUTF8): TWebSocketProtocol;
 var i: Integer;
+  clientUri : RawUtf8;
 begin
   result := nil;
   if self=nil then
     exit;
+  clientUri :=  Split(aClientURI, '?');
   fSafe.Lock;
   try
     for i := 0 to length(fProtocols)-1 do
       with fProtocols[i] do
-      if ((fURI='') or IdemPropNameU(fURI,aClientURI)) and
+      if ((fURI='') or IdemPropNameU(fURI,clientUri)) and
          SetSubprotocol(aProtocolName) then begin
-        result := fProtocols[i].Clone(aClientURI);
+        result := fProtocols[i].Clone(clientUri);
         result.fName := aProtocolName;
         exit;
       end;
@@ -2321,15 +2323,17 @@ end;
 
 function TWebSocketProtocolList.CloneByURI(const aClientURI: RawUTF8): TWebSocketProtocol;
 var i: integer;
+  clientUri : RawUtf8;
 begin
   result := nil;
   if (self=nil) or (aClientURI='') then
     exit;
+  clientUri :=  Split(aClientURI, '?');
   fSafe.Lock;
   try
     for i := 0 to length(fProtocols)-1 do
-      if IdemPropNameU(fProtocols[i].fURI,aClientURI) then begin
-        result := fProtocols[i].Clone(aClientURI);
+      if IdemPropNameU(fProtocols[i].fURI,clientUri) then begin
+        result := fProtocols[i].Clone(clientUri);
         exit;
       end;
   finally


### PR DESCRIPTION
Parameters cannot be passed during a WebSocket connection.
for example(javascript):

let socket = new WebSocket("ws://" + serverIp + ":" + serverPort + "/baseuri?param1=123", "protocol1");

At this time, the baseuri cannot be matched.

After modification, it can:
Server.Settings.OnClientConnected  :=  OnClientConnected;

procedure TServer.OnClientConnected(Sender: TObject);
var
  proc : TWebSocketProcessServer;
  socket : TWebSocketServerSocket;
begin
  proc  :=  Sender as TWebSocketProcessServer;
  socket  :=  proc.Socket as TWebSocketServerSocket;
  //parse parameters: socket.url = /baseuri?param1=123
end;