### PR TITLE
Increased buffer in GetHeader due to token length

### DIFF
--- a/SynCrtSock.pas
+++ b/SynCrtSock.pas
@@ -6973,7 +6973,7 @@ var s,c: SockString;
     i, len: PtrInt;
     err: integer;
     P: PAnsiChar;
-    line: array[0..4095] of AnsiChar; // avoid most memory allocation
+    line: array[0..8191] of AnsiChar; // avoid most memory allocation
 begin
   HeaderFlags := [];
   fBodyRetrieved := false;


### PR DESCRIPTION
In an OIDC auth scenario - we lost the tokens, since they exceeded the allocated 4096 buffer slightly - increasing it solved the issue.