### PR TITLE
Support for >= XE8 for FMX for SynTaskDialog4Lazarus

### DIFF
--- a/SQLite3/Samples/ThirdPartyDemos/Ondrej/SynTaskDialog4Lazarus/FMXUtil.inc.pas
+++ b/SQLite3/Samples/ThirdPartyDemos/Ondrej/SynTaskDialog4Lazarus/FMXUtil.inc.pas
@@ -105,7 +105,11 @@ begin
   F := F-D;
 end;
 
+{$IF (CompilerVersion >= 28)}   //TButton, TLabel inherit from TPresentedTextControl since XE8
+function FMXMeasureText( s:string; C : TPresentedTextControl; MaxWidth : Single; WordWrap : boolean ):TRectF;
+{$ELSE}
 function FMXMeasureText( s:string; C : TTextControl; MaxWidth : Single; WordWrap : boolean ):TRectF;
+{$IFEND}
 var
   R : TRectF;
 begin
@@ -117,3 +121,7 @@ begin
   C.Canvas.MeasureText( R, s, WordWrap, [], TTextAlign.Leading, TTextAlign.Leading );
   Result := R;
 end;
+
+
+
+


### PR DESCRIPTION
ThirdPartyDemo SynTaskDialog4Lazarus does not compile under XE8/FireMonkey:

> SynTaskDialog.pas(982): E2010 Incompatible types: 'TTextControl' and 'TLabel'

Since XE8 TButton, TLabel inherit from TPresentedTextControl, not from TTextControl anymore.

This patch allows the usage under XE8/FMX. 