### PR TITLE
fix Delphi 13 compilation error

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -59279,9 +59279,9 @@ end;
 
 function GetDelphiCompilerVersion: RawUTF8;
 begin
-  result :=
+  result := ''
 {$ifdef FPC}
-  'Free Pascal'
+  +'Free Pascal'
   {$ifdef VER2_6_4}+' 2.6.4'{$endif}
   {$ifdef VER3_0_0}+' 3.0.0'{$endif}
   {$ifdef VER3_0_1}+' 3.0.1'{$endif}
@@ -59290,37 +59290,38 @@ begin
   {$ifdef VER3_2}  +' 3.2'  {$endif}
   {$ifdef VER3_3_1}+' 3.3.1'{$endif}
 {$else}
-  {$ifdef VER130} 'Delphi 5'{$endif}
+  {$ifdef VER130}+'Delphi 5'{$endif}
   {$ifdef CONDITIONALEXPRESSIONS}  // Delphi 6 or newer
-    {$if     defined(KYLIX3)}'Kylix 3'
-    {$elseif defined(VER140)}'Delphi 6'
-    {$elseif defined(VER150)}'Delphi 7'
-    {$elseif defined(VER160)}'Delphi 8'
-    {$elseif defined(VER170)}'Delphi 2005'
-    {$elseif defined(VER185)}'Delphi 2007'
-    {$elseif defined(VER180)}'Delphi 2006'
-    {$elseif defined(VER200)}'Delphi 2009'
-    {$elseif defined(VER210)}'Delphi 2010'
-    {$elseif defined(VER220)}'Delphi XE'
-    {$elseif defined(VER230)}'Delphi XE2'
-    {$elseif defined(VER240)}'Delphi XE3'
-    {$elseif defined(VER250)}'Delphi XE4'
-    {$elseif defined(VER260)}'Delphi XE5'
-    {$elseif defined(VER265)}'AppMethod 1'
-    {$elseif defined(VER270)}'Delphi XE6'
-    {$elseif defined(VER280)}'Delphi XE7'
-    {$elseif defined(VER290)}'Delphi XE8'
-    {$elseif defined(VER300)}'Delphi 10 Seattle'
-    {$elseif defined(VER310)}'Delphi 10.1 Berlin'
-    {$elseif defined(VER320)}'Delphi 10.2 Tokyo'
-    {$elseif defined(VER330)}'Delphi 10.3 Rio'
-    {$elseif defined(VER340)}'Delphi 10.4 Sydney'
-    {$elseif defined(VER350)}'Delphi 11 Alexandria'
-    {$elseif defined(VER360)}'Delphi 11.1 Next'
+    {$if     defined(KYLIX3)}+'Kylix 3'
+    {$elseif defined(VER140)}+'Delphi 6'
+    {$elseif defined(VER150)}+'Delphi 7'
+    {$elseif defined(VER160)}+'Delphi 8'
+    {$elseif defined(VER170)}+'Delphi 2005'
+    {$elseif defined(VER185)}+'Delphi 2007'
+    {$elseif defined(VER180)}+'Delphi 2006'
+    {$elseif defined(VER200)}+'Delphi 2009'
+    {$elseif defined(VER210)}+'Delphi 2010'
+    {$elseif defined(VER220)}+'Delphi XE'
+    {$elseif defined(VER230)}+'Delphi XE2'
+    {$elseif defined(VER240)}+'Delphi XE3'
+    {$elseif defined(VER250)}+'Delphi XE4'
+    {$elseif defined(VER260)}+'Delphi XE5'
+    {$elseif defined(VER265)}+'AppMethod 1'
+    {$elseif defined(VER270)}+'Delphi XE6'
+    {$elseif defined(VER280)}+'Delphi XE7'
+    {$elseif defined(VER290)}+'Delphi XE8'
+    {$elseif defined(VER300)}+'Delphi 10 Seattle'
+    {$elseif defined(VER310)}+'Delphi 10.1 Berlin'
+    {$elseif defined(VER320)}+'Delphi 10.2 Tokyo'
+    {$elseif defined(VER330)}+'Delphi 10.3 Rio'
+    {$elseif defined(VER340)}+'Delphi 10.4 Sydney'
+    {$elseif defined(VER350)}+'Delphi 11 Alexandria'
+    {$elseif defined(VER360)}+'Delphi 12 Athens'
+    {$elseif defined(VER370)}+'Delphi 13 Florence'
     {$ifend}
   {$endif CONDITIONALEXPRESSIONS}
 {$endif FPC}
-{$ifdef CPU64} +' 64 bit' {$else} +' 32 bit' {$endif}
+{$ifdef CPU64} +' 64 bit' {$else} +' 32 bit' {$endif};
 end;
 
 


### PR DESCRIPTION
Updates version detection to include minor releases for Delphi 11 and 12, and adds support for the newly released Delphi 13. 
The {$else} branch now serves as a placeholder for future versions (e.g., Delphi 14).