### PR TITLE
Oracle: fetch all rows even in case of warning

### DIFF
--- a/SynDBOracle.pas
+++ b/SynDBOracle.pas
@@ -2606,6 +2606,10 @@ begin
   case Status of
   OCI_SUCCESS:
     fRowFetched := fRowCount; // all rows successfully retrieved
+  OCI_SUCCESS_WITH_INFO: begin
+    fRowFetched := fRowCount; // all rows successfully retrieved but got a warning
+    OCI.Check(nil,self,Status,fError,false); // will log warning message
+  end;
   OCI_NO_DATA: begin
     OCI.AttrGet(fStatement,OCI_HTYPE_STMT,@fRowFetched,nil,OCI_ATTR_ROWS_FETCHED,fError);
     fRowFetchedEnded := true;


### PR DESCRIPTION
Oracle: fetch all rows even in case of warning. For example: ORA-24347 Warning of a NULL column in an aggregate function. The same actual for mORMot2 